### PR TITLE
add .stl file

### DIFF
--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -19,6 +19,9 @@ import vtk
 import matplotlib.pyplot as plt
 import paddle
 import pyvista as pv
+from pysdf import SDF
+import trimesh
+import time
 
 
 # Geometry
@@ -90,15 +93,10 @@ class Geometry:
         self.mesh_file.clear()
 
     def _is_inside_mesh(self, points, filename):
-        flag_inside_mesh = np.full(len(points), False, dtype='bool')
-        mesh_model = pv.read(filename)
-        for i in range(len(points)):
-            # TODO The vertice[0,0,0] is not applicable in all cases
-            point = [[0, 0, 0], points[i]]
-            point_poly = pv.PolyData(point)
-            select = point_poly.select_enclosed_points(mesh_model)
-            flag_inside_mesh[i] = select['SelectedPoints'][1]
-        return flag_inside_mesh
+        mesh_model = trimesh.load(filename)
+        f = SDF(mesh_model.vertices, mesh_model.faces)
+        origin_contained = f.contains(points)
+        return origin_contained
 
     def _get_points_from_meshfile(self, filename):
         mesh_model = pv.read(filename)

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -20,8 +20,6 @@ import matplotlib.pyplot as plt
 import paddle
 import pyvista as pv
 from pysdf import SDF
-import trimesh
-import time
 
 
 # Geometry
@@ -93,13 +91,21 @@ class Geometry:
         self.mesh_file.clear()
 
     def _is_inside_mesh(self, points, filename):
-        mesh_model = trimesh.load(filename)
-        f = SDF(mesh_model.vertices, mesh_model.faces)
-        origin_contained = f.contains(points)
+
+        mesh_model = pv.read(filename)
+        faces_as_array = mesh_model.faces.reshape(
+            (mesh_model.n_faces, 4))[:, 1:]
+
+        sdf = SDF(mesh_model.points, faces_as_array)
+
+        origin_contained = sdf.contains(points)
+
         return origin_contained
 
     def _get_points_from_meshfile(self, filename):
+
         mesh_model = pv.read(filename)
+
         return mesh_model.points
 
     # select boundaries from all points and construct disc geometry

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ wget
 scipy
 visualdl
 pyvista
+pysdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas
 wget
 scipy
 visualdl
+pyvista


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add .stl file.

功能描述：
增加对stl文件的识别，可以解析不规则的几何体。引入了两个库，分别是pyvista和pysdf。

使用的example如下：
```
import paddlescience as psci
import numpy as np
import paddle

paddle.seed(1)
np.random.seed(1)

geo = psci.geometry.Rectangular(origin=(0, 0, 0), extent=(2000, 200, 2500))

geo.add_boundary(name="inlet", criteria=lambda x, y, z: abs(x) < 1e-5)
geo.add_boundary(name="outlet", criteria=lambda x, y, z: abs(x - 2000) < 1e-5)
geo.add_boundary(name='wing', filename='NACA.STL')

# discretize geometry
geo_disc = geo.discretize(method="uniform", npoints=[201, 21, 26])

# N-S
pde = psci.pde.NavierStokes(
    nu=0.01, rho=1.0, dim=3, time_dependent=False, weight=0.0001)

# set bounday condition
bc_inlet_u = psci.bc.Dirichlet('u', rhs=1.0)
bc_inlet_v = psci.bc.Dirichlet('v', rhs=0.0)
bc_inlet_w = psci.bc.Dirichlet('w', rhs=0.0)

bc_outlet_p = psci.bc.Dirichlet('p', rhs=0.0)

# boundary on wing
bc_wing_u = psci.bc.Dirichlet('u', rhs=0.0)
bc_wing_v = psci.bc.Dirichlet('v', rhs=0.0)
bc_wing_w = psci.bc.Dirichlet('w', rhs=0.0)

# add bounday and boundary condition
pde.add_bc("inlet", bc_inlet_u, bc_inlet_v, bc_inlet_w)
pde.add_bc("outlet", bc_outlet_p)
pde.add_bc("wing", bc_wing_u, bc_wing_v, bc_wing_w)

# discretization pde
pde_disc = pde.discretize(geo_disc=geo_disc)

# Network
net = psci.network.FCNet(
    num_ins=3, num_outs=4, num_layers=10, hidden_size=50, activation='tanh')

# Loss
loss = psci.loss.L2(p=2)

# Algorithm
algo = psci.algorithm.PINNs(net=net, loss=loss)

# Optimizer
opt = psci.optimizer.Adam(learning_rate=0.001, parameters=net.parameters())

# Solver
solver = psci.solver.Solver(pde=pde_disc, algo=algo, opt=opt)
solution = solver.solve(num_epoch=1000)

psci.visu.save_vtk(geo_disc=pde_disc.geometry, data=solution)
```
识别stl文件的API接口示例为：
```
geo.add_boundary(name='wing', filename='NACA.STL')
```

利用paraview展示的效果如下：
![image](https://user-images.githubusercontent.com/85323580/176075436-62cfd2a2-dd98-458f-9557-f6071323d613.png)
识别出机翼形状，选取中间截面展示。