### PR TITLE
Supports geometries such as triangles via pyvista polydata.

### DIFF
--- a/paddlescience/geometry/__init__.py
+++ b/paddlescience/geometry/__init__.py
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 from .rectangular import Rectangular, Cube, CircleInRectangular, CylinderInCube
+from .triangle import Triangle
 from .geometry_discrete import GeometryDiscrete

--- a/paddlescience/geometry/__init__.py
+++ b/paddlescience/geometry/__init__.py
@@ -13,5 +13,4 @@
 # limitations under the License.
 
 from .rectangular import Rectangular, Cube, CircleInRectangular, CylinderInCube
-from .triangle import Triangle
 from .geometry_discrete import GeometryDiscrete

--- a/paddlescience/geometry/__init__.py
+++ b/paddlescience/geometry/__init__.py
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 from .rectangular import Rectangular, Cube, CircleInRectangular, CylinderInCube
+from .polydata import PolyData
 from .geometry_discrete import GeometryDiscrete

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -30,7 +30,7 @@ class Geometry:
         self.normal = dict()  # boundary normal direction
         self._dtype = config._dtype
 
-    def add_boundary(self, name, criteria=None, normal=None, tri_mesh=None):
+    def add_boundary(self, name, criteria=None, normal=None, filename=None):
         """
         Add (specify) bounday in geometry
 
@@ -48,8 +48,8 @@ class Geometry:
             self.criteria[name] = criteria
             self.normal[name] = normal
 
-        if tri_mesh != None:
-            self.tri_mesh[name] = tri_mesh
+        if filename != None:
+            self.tri_mesh[name] = filename
 
     def delete_boundary(self, name):
         """

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -24,11 +24,12 @@ from pysdf import SDF
 
 # Geometry
 class Geometry:
-    def __init__(self):
+    def __init__(self, tri_mesh=None):
         self.criteria = dict()  # criteria (lambda) defining boundary
         self.mesh_file = dict()
         self.normal = dict()  # boundary normal direction
         self._dtype = config._dtype
+        self.tri_mesh = tri_mesh
 
     def add_boundary(self, name, criteria=None, normal=None, filename=None):
         """
@@ -166,3 +167,35 @@ class Geometry:
             geo_disc.padding(nproc)
 
         return geo_disc
+
+    def __sub__(self, other):
+        return Geometry(self.tri_mesh.boolean_difference(other.tri_mesh))
+
+    def discretize(self, method="sampling", npoints=100, padding=True):
+        pv_mesh = self.tri_mesh
+
+        return pv_mesh.points
+        '''
+        while True:
+            if len(pv_mesh.points) < npoints:
+                pv_mesh = pv_mesh.subdivide(1, 'linear')
+            else:
+                break
+        
+        triangle = pv_mesh
+        triangle_points = np.random.choice(len(triangle.points), npoints)
+        return triangle.points[triangle_points,:]
+        '''
+        # Get (x_min,y_min,z_min) (x_max,y_max,z_max)
+        x_min = np.min(pv_mesh.points[:, 0])
+        x_max = np.max(pv_mesh.points[:, 0])
+
+        y_min = np.min(pv_mesh.points[:, 1])
+        y_max = np.max(pv_mesh.points[:, 1])
+
+        z_min = np.min(pv_mesh.points[:, 2])
+        z_max = np.max(pv_mesh.points[:, 2])
+
+        # sampling in the cube
+
+        # delete or get points in the mesh

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -28,6 +28,7 @@ class Geometry:
         self.criteria = dict()  # criteria (lambda) defining boundary
         self.tri_mesh = dict()
         self.normal = dict()  # boundary normal direction
+        self.pv_mesh = None
         self._dtype = config._dtype
 
     def add_boundary(self, name, criteria=None, normal=None, filename=None):
@@ -120,6 +121,10 @@ class Geometry:
 
         # TODO(liu-xiandong): Need to increase sampling points on the boundary
         return mesh_model.points
+
+    def __sub__(self, other):
+        self.tri_mesh['subtraction' + str(len(self.tri_mesh))] = other.pv_mesh
+        return self
 
     # select boundaries from all points and construct disc geometry
     def _mesh_to_geo_disc(self, points, padding=True):

--- a/paddlescience/geometry/polydata.py
+++ b/paddlescience/geometry/polydata.py
@@ -27,8 +27,8 @@ class PolyData(Geometry):
     Three dimentional PolyData
 
     Parameters:
-        vertices(integer list | float list | double list): Cordinate of points. Note that only 3D point data is supported currently.
-        faces(integer list): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
+        vertices(integer numpy array | float numpy array | double numpy array): Cordinate of points. Note that only 3D point data is supported currently.
+        faces(integer numpy array): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
 
     Example:
         >>> import paddlescience as psci

--- a/paddlescience/geometry/polydata.py
+++ b/paddlescience/geometry/polydata.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR boundaryS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .geometry_discrete import GeometryDiscrete
+from .geometry import Geometry
+import numpy as np
+import math
+from scipy.stats import qmc
+import pyvista as pv
+
+__all__ = ['PolyData']
+
+
+# Rectangular
+class PolyData(Geometry):
+    # """
+    # Two dimentional rectangular or three dimentional cube
+
+    # Parameters:
+    #     origin: Cordinate of left-bottom point of rectangular
+    #     extent: Extent of rectangular
+
+    # Example:
+    #     >>> import paddlescience as psci
+    #     >>> geo2d = psci.geometry.Rectangular(origin=(0.0,0.0), extent=(1.0,1.0))
+    #     >>> geo3d = psci.geometry.Rectangular(origin=(0.0,0.0,0.0), extent=(2.0,2.0,2.0))
+    # """
+
+    def __init__(self, vertices, faces):
+        super(PolyData, self).__init__()
+
+        triangle = pv.PolyData(vertices, faces)
+        triangle = triangle.triangulate()
+        self.pv_mesh = triangle

--- a/paddlescience/geometry/polydata.py
+++ b/paddlescience/geometry/polydata.py
@@ -16,7 +16,6 @@ from .geometry_discrete import GeometryDiscrete
 from .geometry import Geometry
 import numpy as np
 import math
-from scipy.stats import qmc
 import pyvista as pv
 
 __all__ = ['PolyData']
@@ -24,18 +23,30 @@ __all__ = ['PolyData']
 
 # Rectangular
 class PolyData(Geometry):
-    # """
-    # Two dimentional rectangular or three dimentional cube
+    """
+    Three dimentional PolyData
 
-    # Parameters:
-    #     origin: Cordinate of left-bottom point of rectangular
-    #     extent: Extent of rectangular
+    Parameters:
+        vertices: Cordinate of points. Note that only 3D point data is supported currently.
+        faces: Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
 
-    # Example:
-    #     >>> import paddlescience as psci
-    #     >>> geo2d = psci.geometry.Rectangular(origin=(0.0,0.0), extent=(1.0,1.0))
-    #     >>> geo3d = psci.geometry.Rectangular(origin=(0.0,0.0,0.0), extent=(2.0,2.0,2.0))
-    # """
+    Example:
+        >>> import paddlescience as psci
+        >>> vertices = np.array([[3, 3, 0], [7, 3, 0], 
+        >>>    [5, 7, 0], [3, 3, 0.5], 
+        >>>    [7, 3, 0.5], [5, 7, 0.5]])
+        >>> # Right-hand rule
+        >>> faces = np.hstack(
+        >>>    [
+        >>>        [3, 0, 2, 1],  # triangle
+        >>>        [3, 3, 4, 5],  # triangle
+        >>>        [4, 0, 3, 5, 2], # square
+        >>>        [4, 1, 2, 5, 4], # square
+        >>>        [4, 0, 1, 4, 3],  # square
+        >>>    ]
+        >>> )
+        >>> triangle = psci.geometry.PolyData(vertices, faces)
+    """
 
     def __init__(self, vertices, faces):
         super(PolyData, self).__init__()

--- a/paddlescience/geometry/polydata.py
+++ b/paddlescience/geometry/polydata.py
@@ -27,8 +27,8 @@ class PolyData(Geometry):
     Three dimentional PolyData
 
     Parameters:
-        vertices: Cordinate of points. Note that only 3D point data is supported currently.
-        faces: Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
+        vertices(int | float | double): Cordinate of points. Note that only 3D point data is supported currently.
+        faces(int): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
 
     Example:
         >>> import paddlescience as psci

--- a/paddlescience/geometry/polydata.py
+++ b/paddlescience/geometry/polydata.py
@@ -27,8 +27,8 @@ class PolyData(Geometry):
     Three dimentional PolyData
 
     Parameters:
-        vertices(integer numpy array | float numpy array | double numpy array): Cordinate of points. Note that only 3D point data is supported currently.
-        faces(integer numpy array): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
+        vertices(integer numpy.ndarray | float numpy.ndarray | double numpy.ndarray): Cordinate of points. Note that only 3D point data is supported currently.
+        faces(integer numpy.ndarray): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
 
     Example:
         >>> import paddlescience as psci

--- a/paddlescience/geometry/polydata.py
+++ b/paddlescience/geometry/polydata.py
@@ -28,7 +28,7 @@ class PolyData(Geometry):
 
     Parameters:
         vertices(integer numpy.ndarray | float numpy.ndarray | double numpy.ndarray): Cordinate of points. Note that only 3D point data is supported currently.
-        faces(integer numpy.ndarray): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
+        faces(integer numpy.ndarray): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule. 
 
     Example:
         >>> import paddlescience as psci

--- a/paddlescience/geometry/polydata.py
+++ b/paddlescience/geometry/polydata.py
@@ -27,8 +27,8 @@ class PolyData(Geometry):
     Three dimentional PolyData
 
     Parameters:
-        vertices(int | float | double): Cordinate of points. Note that only 3D point data is supported currently.
-        faces(int): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
+        vertices(integer list | float list | double list): Cordinate of points. Note that only 3D point data is supported currently.
+        faces(integer list): Face connectivity array. Note that faces must contain padding indicating the number of points in the face. And it needs to satisfy the right-hand rule.
 
     Example:
         >>> import paddlescience as psci

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -16,6 +16,7 @@ from .geometry_discrete import GeometryDiscrete
 from .geometry import Geometry
 import numpy as np
 import math
+from scipy.stats import qmc
 
 __all__ = ['Rectangular', 'Cube', 'CircleInRectangular', 'CylinderInCube']
 
@@ -74,8 +75,218 @@ class Rectangular(Geometry):
             points = self._uniform_mesh(npoints)
         elif method == "sampling":
             points = self._sampling_mesh(npoints)
+        elif method == "sampler_halton":
+            points = self._sampling_halton(npoints)
+        elif method == "sampler_sobol":
+            points = self._sampling_sobol(npoints)
+        elif method == "sampler_lhs":
+            points = self._sampling_lhs(npoints)
+        else:
+            assert 0, "The discretize method can only be uniform, sampling or sampler_halton."
 
         return super(Rectangular, self)._mesh_to_geo_disc(points, padding)
+
+    def _sampling_boundary(self, npoints):
+        steps = list()
+
+        if self.ndims == 1:
+            steps.append(np.array(self.origin[0], dtype=self._dtype))
+            steps.append(np.array(self.extent[0], dtype=self._dtype))
+        elif self.ndims == 2:
+            # nx: number of points on x-axis
+            # ny: number of points on y-axis
+            # nx * ny = npoints 
+            # nx / ny = lx / ly
+            lx = self.extent[0] - self.origin[0]
+            ly = self.extent[1] - self.origin[1]
+            ny = np.sqrt(float(npoints) * ly / lx)
+            nx = float(npoints) / ny
+            nx = int(nx)
+            ny = int(ny)
+
+            x1, y1 = self.origin
+            x2, y2 = self.extent
+
+            # four boundary: down, top, left, right
+            origin = [x1, y1]
+            extent = [x2, y1]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx))
+
+            origin = [x1, y2]
+            extent = [x2, y2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx))
+
+            origin = [x1, y1]
+            extent = [x1, y2]
+            steps.append(self._sampling_mesh_interior(origin, extent, ny))
+
+            origin = [x2, y1]
+            extent = [x2, y2]
+            steps.append(self._sampling_mesh_interior(origin, extent, ny))
+
+            # four vertex
+            steps.append(np.array([x1, y1], dtype=self._dtype))
+            steps.append(np.array([x1, y2], dtype=self._dtype))
+            steps.append(np.array([x2, y1], dtype=self._dtype))
+            steps.append(np.array([x2, y2], dtype=self._dtype))
+        elif self.ndims == 3:
+
+            # nx: number of points on x-axis
+            # ny: number of points on y-axis
+            # nz: number of points on z-axis
+            # nx * ny * nz = npoints 
+            # nx / lx = ny / ly = nz / lz
+            lx = self.extent[0] - self.origin[0]
+            ly = self.extent[1] - self.origin[1]
+            lz = self.extent[2] - self.origin[2]
+            nz = math.pow(float(npoints + 1) * lz**2 / (lx * ly), 1.0 / 3.0)
+            nx = nz * lx / lz
+            ny = nz * ly / lz
+            nx = int(nx)
+            ny = int(ny)
+            nz = int(nz)
+
+            x1, y1, z1 = self.origin
+            x2, y2, z2 = self.extent
+
+            # six faces: down, top, left, right, front, back
+            origin = [x1, y1, z1]
+            extent = [x2, y2, z1]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx * ny))
+
+            origin = [x1, y1, z2]
+            extent = [x2, y2, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx * ny))
+
+            origin = [x1, y1, z1]
+            extent = [x1, y2, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, ny * nz))
+
+            origin = [x2, y1, z1]
+            extent = [x2, y2, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, ny * nz))
+
+            origin = [x1, y1, z1]
+            extent = [x2, y1, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx * nz))
+
+            origin = [x1, y2, z1]
+            extent = [x2, y2, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx * nz))
+
+            # twelve edges
+            origin = [x1, y1, z1]
+            extent = [x2, y1, z1]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx))
+
+            origin = [x2, y1, z1]
+            extent = [x2, y2, z1]
+            steps.append(self._sampling_mesh_interior(origin, extent, ny))
+
+            origin = [x2, y2, z1]
+            extent = [x1, y2, z1]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx))
+
+            origin = [x1, y2, z1]
+            extent = [x1, y1, z1]
+            steps.append(self._sampling_mesh_interior(origin, extent, ny))
+
+            origin = [x1, y1, z2]
+            extent = [x2, y1, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx))
+
+            origin = [x2, y1, z2]
+            extent = [x2, y2, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, ny))
+
+            origin = [x2, y2, z2]
+            extent = [x1, y2, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nx))
+
+            origin = [x1, y2, z2]
+            extent = [x1, y1, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, ny))
+
+            origin = [x1, y1, z1]
+            extent = [x1, y1, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nz))
+
+            origin = [x2, y1, z1]
+            extent = [x2, y1, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nz))
+
+            origin = [x2, y2, z1]
+            extent = [x2, y2, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nz))
+
+            origin = [x1, y1, z1]
+            extent = [x1, y1, z2]
+            steps.append(self._sampling_mesh_interior(origin, extent, nz))
+
+            # eight vertex
+            steps.append(np.array([x1, y1, z1], dtype=self._dtype))
+            steps.append(np.array([x2, y1, z1], dtype=self._dtype))
+            steps.append(np.array([x2, y2, z1], dtype=self._dtype))
+            steps.append(np.array([x1, y2, z1], dtype=self._dtype))
+            steps.append(np.array([x1, y1, z2], dtype=self._dtype))
+            steps.append(np.array([x2, y1, z2], dtype=self._dtype))
+            steps.append(np.array([x2, y2, z2], dtype=self._dtype))
+            steps.append(np.array([x1, y2, z2], dtype=self._dtype))
+
+        return np.vstack(steps)
+
+    def _sampling_halton(self, npoints):
+
+        sampler = qmc.Halton(d=self.ndims, scramble=False)
+
+        sample = sampler.random(n=npoints)
+
+        l_bounds = self.origin
+        u_bounds = self.extent
+
+        result = qmc.scale(sample, l_bounds, u_bounds)
+
+        result = np.array(result).astype(self._dtype)
+
+        boundary_points = self._sampling_boundary(npoints)
+
+        return np.concatenate((result, boundary_points), axis=0)
+
+    def _sampling_sobol(self, npoints):
+
+        sampler = qmc.Sobol(d=self.ndims, scramble=False)
+
+        # log_points = np.ceil(np.log2(npoints))
+        # sample = sampler.random_base2(m=log_points)
+        sample = sampler.random(n=npoints)
+
+        l_bounds = self.origin
+        u_bounds = self.extent
+
+        result = qmc.scale(sample, l_bounds, u_bounds)
+
+        result = np.array(result).astype(self._dtype)
+
+        boundary_points = self._sampling_boundary(npoints)
+
+        return np.concatenate((result, boundary_points), axis=0)
+
+    def _sampling_lhs(self, npoints):
+
+        sampler = qmc.LatinHypercube(d=self.ndims)
+
+        sample = sampler.random(n=npoints)
+
+        l_bounds = self.origin
+        u_bounds = self.extent
+
+        result = qmc.scale(sample, l_bounds, u_bounds)
+
+        result = np.array(result).astype(self._dtype)
+
+        boundary_points = self._sampling_boundary(npoints)
+
+        return np.concatenate((result, boundary_points), axis=0)
 
     def _sampling_mesh(self, npoints):
 

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -75,14 +75,14 @@ class Rectangular(Geometry):
             points = self._uniform_mesh(npoints)
         elif method == "sampling":
             points = self._sampling_mesh(npoints)
-        elif method == "sampler_halton":
+        elif method == "quasi_halton":
             points = self._sampling_halton(npoints)
-        elif method == "sampler_sobol":
+        elif method == "quasi_sobol":
             points = self._sampling_sobol(npoints)
-        elif method == "sampler_lhs":
+        elif method == "quasi_lhs":
             points = self._sampling_lhs(npoints)
         else:
-            assert 0, "The discretize method can only be uniform, sampling or sampler_halton."
+            assert 0, "The discretize method can only be uniform, sampling or quasi sampler."
 
         return super(Rectangular, self)._mesh_to_geo_disc(points, padding)
 

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -60,7 +60,7 @@ class Rectangular(Geometry):
         Discretize rectangular
 
         Parameters:
-            method ("uniform" / "sampling"): Discretize rectangular using method "uniform" or "sampling"
+            method ("uniform" / "sampling" / "quasi_halton" / "quasi_sobol"/ "quasi_lhs"): Discretize rectangular using method "uniform", "sampling", "quasi_halton", "quasi_sobol" or "quasi_lhs".
             npoints (integer / integer list): Number of points 
 
         Example:
@@ -69,6 +69,9 @@ class Rectangular(Geometry):
             >>> geo.discretize(method="uniform", npoints=100)
             >>> geo.discretize(method="uniform", npoints=[10, 20])
             >>> geo.discretize(method="sampling", npoints=200)
+            >>> geo.discretize(method="quasi_halton", npoints=200)
+            >>> geo.discretize(method="quasi_sobol", npoints=200)
+            >>> geo.discretize(method="quasi_lhs", npoints=200)
         """
 
         if method == "uniform":

--- a/paddlescience/visu/visu_vtk.py
+++ b/paddlescience/visu/visu_vtk.py
@@ -70,16 +70,19 @@ def save_vtk(filename="output", time_array=None, geo_disc=None, data=None):
         axis_x = points_vtk[0]
         axis_y = points_vtk[1]
         axis_z = points_vtk[2]
-        for t in range(nt):
-            fpname = filename + "-t" + str(t + 1) + "-p" + str(nrank)
-            pointsToVTK(fpname, axis_x, axis_y, axis_z, data=data_vtk[t])
     elif ndims == 2:
         axis_x = points_vtk[0]
         axis_y = points_vtk[1]
         axis_z = np.zeros(npoints, dtype=config._dtype)
+
+    if data is not None:
         for t in range(nt):
             fpname = filename + "-t" + str(t + 1) + "-p" + str(nrank)
             pointsToVTK(fpname, axis_x, axis_y, axis_z, data=data_vtk[t])
+    else:
+        for t in range(nt):
+            fpname = filename + "-t" + str(t + 1) + "-p" + str(nrank)
+            __save_vtk_raw(filename=fpname, cordinate=np.array(points_vtk).T)
 
 
 def __save_vtk_raw(filename="output", cordinate=None, data=None):
@@ -101,8 +104,8 @@ def __save_vtk_raw(filename="output", cordinate=None, data=None):
         axis_z = cordinate[:, 2].copy()
         pointsToVTK(filename, axis_x, axis_y, axis_z, data=data_vtk)
     elif ndims == 2:
-        axis_x = cordinate[:, 0].copy()
-        axis_y = cordinate[:, 1].copy()
+        axis_x = cordinate[:, 0].copy().astype(config._dtype)
+        axis_y = cordinate[:, 1].copy().astype(config._dtype)
         axis_z = np.zeros(npoints, dtype=config._dtype)
         pointsToVTK(filename, axis_x, axis_y, axis_z, data=data_vtk)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
Supports geometries such as triangles via pyvista polydata.
<!-- Describe what this PR does -->

功能描述：
1、引入pyvista定义的polydata，通过vertices和faces可以灵活地支持多种几何构造，下面示例展示了三角形的构造
2、在rectangle上增加准随机采样，包括lhs、sobol、halton等
3、初步支持减法的布尔运算

使用示例如下：
```
import paddlescience as psci
import numpy as np
import paddle

paddle.seed(1)
np.random.seed(1)

# triangle
vertices = np.array([[3, 3, 0], [7, 3, 0], 
            [5, 7, 0], [3, 3, 0.5], 
            [7, 3, 0.5], [5, 7, 0.5]])
# mesh faces 
# Right-hand rule
faces = np.hstack(
    [
        [3, 0, 2, 1],  # triangle
        [3, 3, 4, 5],  # triangle
        [4, 0, 3, 5, 2], # square
        [4, 1, 2, 5, 4], # square
        [4, 0, 1, 4, 3],  # square
    ]
)
triangle = psci.geometry.PolyData(vertices, faces)

geo = psci.geometry.Rectangular(origin=(0, 0, 0), extent=(10, 10, 0.5))

geo = geo - triangle

geo.add_boundary(name="inlet", criteria=lambda x, y, z: abs(x) < 1e-5)
geo.add_boundary(name="outlet", criteria=lambda x, y, z: abs(x - 10) < 1e-5)

# discretize geometry
geo_disc = geo.discretize(method="quasi_sobol", npoints=500000)

psci.visu.save_vtk(filename="out", geo_disc=geo_disc)
```

可视化效果如下：
![image](https://user-images.githubusercontent.com/85323580/179499235-4dcbe192-1aba-43b4-9794-8a8ebecbc224.png)
