### PR TITLE
fix PR120 CINN support bug

### DIFF
--- a/paddlescience/config.py
+++ b/paddlescience/config.py
@@ -97,7 +97,14 @@ def cinn_enabled():
     '''
     cinn_flag = os.getenv('FLAGS_use_cinn', '0')
     check_cinn_set = cinn_flag == "1" or cinn_flag.lower() == "true"
-    if check_cinn_set:
+    return check_cinn_set
+
+
+def enable_cinn():
+    '''
+    Enable CINN based on static graph mode and automatic differentiation basic operator.
+    Please ensure FLAGS_use_cinn is set to 1 or true. Ref https://github.com/PaddlePaddle/CINN
+    '''
+    if cinn_enabled():
         enable_static()
         enable_prim()
-    return check_cinn_set

--- a/paddlescience/solver/solver.py
+++ b/paddlescience/solver/solver.py
@@ -419,7 +419,7 @@ class Solver(object):
                 self.opt.minimize(self.loss)
 
                 # new ad
-                if config.prim_enabled():
+                if config.prim_enabled() and not config.cinn_enabled():
                     config.prim2orig()
 
             # startup program
@@ -462,6 +462,7 @@ class Solver(object):
 
         if config.cinn_enabled():
             begin = time.time()
+            print("CINN is currently used.")
             compiled_program = utils.cinn_compile(self.train_program,
                                                   self.loss.name, fetches)
         else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/PaddleScience/pull/120 为`psci.solver.Solver`接口添加CINN支持，但由于`config.prim_enabled()`开启时就会走`config.prim2orig()`逻辑转换为原生算子，导致模型根本没能走到CINN。本PR修复了该问题。