### PR TITLE
Boundary refinement.

### DIFF
--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -38,6 +38,7 @@ class Geometry:
         Parameters:
             name (string): Boundary name
             criteria (lambda function): Lambda function to define boundary.
+            filename (string): Read mesh file to define boundary. The mesh file needs to meet two conditions: 1. It must be watertight. 2. It must be a `Triangular Mesh`.
 
         Example:
             >>> import paddlescience as psci
@@ -100,7 +101,7 @@ class Geometry:
 
         # The mesh must be manifold and need to be triangulate
         if mesh_model.is_manifold is False and mesh_model.is_all_triangles is False:
-            assert 0, "The mesh must be manifold and need to be triangulate."
+            assert 0, "The mesh must be manifold and need to be Triangulate mesh."
 
         # The all the faces of mesh must be triangles
         faces_as_array = mesh_model.faces.reshape(

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -22,26 +22,12 @@ import pyvista as pv
 from pysdf import SDF
 
 
-# Encryption
-class Encryption:
-    def __init__(self, dist, npoints):
-        self.dist = dist
-        self.npoints = npoints
-
-    def get_dist(self):
-        return self.dist
-
-    def get_npoints(self):
-        return self.npoints
-
-
 # Geometry
 class Geometry:
     def __init__(self):
         self.criteria = dict()  # criteria (lambda) defining boundary
         self.tri_mesh = dict()
         self.normal = dict()  # boundary normal direction
-        self.encryption = dict()
         self.pv_mesh = None
         self._dtype = config._dtype
 
@@ -104,10 +90,6 @@ class Geometry:
         self.criteria.clear()
         self.normal.clear()
         self.tri_mesh.clear()
-
-    def _boundary_encryption(self, name, dist, npoints):
-        # record the message 
-        self.encryption[name] = Encryption(dist, npoints)
 
     def _is_inside_mesh(self, points, tri_mesh):
 
@@ -211,5 +193,5 @@ class Geometry:
 
         return geo_disc
 
-    def _sampling_encryption(self, dist, npoints, geo=None):
+    def _sampling_refinement(self, dist, npoints, geo=None):
         pass

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -145,7 +145,7 @@ class Geometry:
         return self
 
     # select boundaries from all points and construct disc geometry
-    def _mesh_to_geo_disc(self, points, padding=True):
+    def _mesh_to_geo_disc(self, points, padding=True, npoints_need=100):
 
         geo_disc = GeometryDiscrete(geometry=self)
 
@@ -196,9 +196,20 @@ class Geometry:
         # extract remain points, i.e. interior points
         geo_disc.interior = points[flag_i, :]
 
+        # if generate more points, remove it
+        total_boundary_points = 0
+        for name in geo_disc.boundary.keys():
+            total_boundary_points += len(geo_disc.boundary[name])
+
+        need_interior_points = npoints_need - total_boundary_points
+        geo_disc.interior = geo_disc.interior[0:need_interior_points, :]
+
         # padding
         if padding:
             nproc = paddle.distributed.get_world_size()
             geo_disc.padding(nproc)
 
         return geo_disc
+
+    def _sampling_encryption(self, dist, npoints, geo=None):
+        pass

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -22,6 +22,19 @@ import pyvista as pv
 from pysdf import SDF
 
 
+# Encryption
+class Encryption:
+    def __init__(self, dist, npoints):
+        self.dist = dist
+        self.npoints = npoints
+
+    def get_dist(self):
+        return self.dist
+
+    def get_npoints(self):
+        return self.npoints
+
+
 # Geometry
 class Geometry:
     def __init__(self):
@@ -94,7 +107,7 @@ class Geometry:
 
     def boundary_encryption(self, name, dist, npoints):
         # record the message 
-        pass
+        self.encryption[name] = Encryption(dist, npoints)
 
     def _is_inside_mesh(self, points, tri_mesh):
 

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -28,6 +28,7 @@ class Geometry:
         self.criteria = dict()  # criteria (lambda) defining boundary
         self.tri_mesh = dict()
         self.normal = dict()  # boundary normal direction
+        self.encryption = dict()
         self.pv_mesh = None
         self._dtype = config._dtype
 

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -91,6 +91,9 @@ class Geometry:
         self.normal.clear()
         self.tri_mesh.clear()
 
+    def boundary_encryption(self, name, dist):
+        pass
+
     def _is_inside_mesh(self, points, tri_mesh):
 
         if isinstance(tri_mesh, str):

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -44,6 +44,7 @@ class Geometry:
             >>> import paddlescience as psci
             >>> rec = psci.geometry.Rectangular(origin=(0.0,0.0), extent=(1.0,1.0))
             >>> rec.add_boundary("top", criteria=lambda x, y : y==1.0) # top boundary
+            >>> rec.add_boundary("geo_boundary", filename="geo_boundary.stl")
         """
 
         if criteria != None:
@@ -101,7 +102,7 @@ class Geometry:
 
         # The mesh must be manifold and need to be triangulate
         if mesh_model.is_manifold is False and mesh_model.is_all_triangles is False:
-            assert 0, "The mesh must be manifold and need to be Triangulate mesh."
+            assert 0, "The mesh must be watertight and need to be Triangulate mesh."
 
         # The all the faces of mesh must be triangles
         faces_as_array = mesh_model.faces.reshape(

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -91,7 +91,8 @@ class Geometry:
         self.normal.clear()
         self.tri_mesh.clear()
 
-    def boundary_encryption(self, name, dist):
+    def boundary_encryption(self, name, dist, npoints):
+        # record the message 
         pass
 
     def _is_inside_mesh(self, points, tri_mesh):
@@ -99,7 +100,7 @@ class Geometry:
         if isinstance(tri_mesh, str):
             mesh_model = pv.read(tri_mesh)
         else:
-            mesh_model = tri_mesh
+            mesh_model = tri_mesh.pv_mesh
 
         # The mesh must be manifold and need to be triangulate
         if mesh_model.is_manifold is False and mesh_model.is_all_triangles is False:
@@ -120,13 +121,13 @@ class Geometry:
         if isinstance(tri_mesh, str):
             mesh_model = pv.read(tri_mesh)
         else:
-            mesh_model = tri_mesh
+            mesh_model = tri_mesh.pv_mesh
 
         # TODO(liu-xiandong): Need to increase sampling points on the boundary
         return mesh_model.points
 
     def __sub__(self, other):
-        self.tri_mesh['subtraction' + str(len(self.tri_mesh))] = other.pv_mesh
+        self.tri_mesh['subtraction' + str(len(self.tri_mesh))] = other
         return self
 
     # select boundaries from all points and construct disc geometry

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -105,7 +105,7 @@ class Geometry:
         self.normal.clear()
         self.tri_mesh.clear()
 
-    def boundary_encryption(self, name, dist, npoints):
+    def _boundary_encryption(self, name, dist, npoints):
         # record the message 
         self.encryption[name] = Encryption(dist, npoints)
 
@@ -147,7 +147,7 @@ class Geometry:
     # select boundaries from all points and construct disc geometry
     def _mesh_to_geo_disc(self, points, padding=True):
 
-        geo_disc = GeometryDiscrete()
+        geo_disc = GeometryDiscrete(geometry=self)
 
         npoints = len(points)
 

--- a/paddlescience/geometry/geometry.py
+++ b/paddlescience/geometry/geometry.py
@@ -178,13 +178,8 @@ class Geometry:
         # extract remain points, i.e. interior points
         geo_disc.interior = points[flag_i, :]
 
-        # if generate more points, remove it
-        total_boundary_points = 0
-        for name in geo_disc.boundary.keys():
-            total_boundary_points += len(geo_disc.boundary[name])
-
-        need_interior_points = npoints_need - total_boundary_points
-        geo_disc.interior = geo_disc.interior[0:need_interior_points, :]
+        # TODO: Note that the currently generated points are inaccurate 
+        # and will be fixed in the future
 
         # padding
         if padding:

--- a/paddlescience/geometry/geometry_discrete.py
+++ b/paddlescience/geometry/geometry_discrete.py
@@ -107,5 +107,8 @@ class GeometryDiscrete:
         return subp
 
     def boundary_encryption(self, name, dist, npoints):
-        # record the message 
-        self.encryption[name] = Encryption(dist, npoints)
+        encryption_points = self.geometry._sampling_encryption(
+            dist, npoints, self.geometry.tri_mesh[name])
+        self.interior = np.concatenate(
+            (self.interior, encryption_points), axis=0)
+        return self

--- a/paddlescience/geometry/geometry_discrete.py
+++ b/paddlescience/geometry/geometry_discrete.py
@@ -108,14 +108,15 @@ class GeometryDiscrete:
 
     def boundary_refinement(self, name, dist, npoints):
         """
-        Refinement of boundaries in geometry
+        Refinement of boundaries in geometry. The boundary `name` must be defined by the `filename` of the `add_boundary` function.
+        If `add_boundary` is called in the way of `criteria`, the boundary name cannot be refined.
 
         Example:
             >>> import paddlescience as psci
             >>> rec = psci.geometry.Rectangular(origin=(0.0,0.0), extent=(1.0,1.0))
-            >>> geo.add_boundary(name="triangle", filename="triangle.stl")
+            >>> geo.add_boundary(name="geo_boundary", filename="geo_boundary.stl")
             >>> geo_disc = geo.discretize(method="quasi_sobol", npoints= 3000)
-            >>> geo_disc = geo_disc.boundary_refinement(name="triangle", dist=1, npoints=20000)
+            >>> geo_disc = geo_disc.boundary_refinement(name="geo_boundary", dist=1, npoints=20000)
         """
 
         refinement_points = self.geometry._sampling_refinement(

--- a/paddlescience/geometry/geometry_discrete.py
+++ b/paddlescience/geometry/geometry_discrete.py
@@ -107,6 +107,17 @@ class GeometryDiscrete:
         return subp
 
     def boundary_refinement(self, name, dist, npoints):
+        """
+        Refinement of boundaries in geometry
+
+        Example:
+            >>> import paddlescience as psci
+            >>> rec = psci.geometry.Rectangular(origin=(0.0,0.0), extent=(1.0,1.0))
+            >>> geo.add_boundary(name="triangle", filename="triangle.stl")
+            >>> geo_disc = geo.discretize(method="quasi_sobol", npoints= 3000)
+            >>> geo_disc = geo_disc.boundary_refinement(name="triangle", dist=1, npoints=20000)
+        """
+
         refinement_points = self.geometry._sampling_refinement(
             dist, npoints, self.geometry.tri_mesh[name])
         self.interior = np.concatenate(

--- a/paddlescience/geometry/geometry_discrete.py
+++ b/paddlescience/geometry/geometry_discrete.py
@@ -106,9 +106,9 @@ class GeometryDiscrete:
 
         return subp
 
-    def boundary_encryption(self, name, dist, npoints):
-        encryption_points = self.geometry._sampling_encryption(
+    def boundary_refinement(self, name, dist, npoints):
+        refinement_points = self.geometry._sampling_refinement(
             dist, npoints, self.geometry.tri_mesh[name])
         self.interior = np.concatenate(
-            (self.interior, encryption_points), axis=0)
+            (self.interior, refinement_points), axis=0)
         return self

--- a/paddlescience/geometry/geometry_discrete.py
+++ b/paddlescience/geometry/geometry_discrete.py
@@ -21,13 +21,16 @@ class GeometryDiscrete:
     Geometry Discrete
     """
 
-    def __init__(self):
+    def __init__(self, geometry=None):
 
         # TODO: data structure uniformation
         self.interior = None
         self.boundary = dict()
         self.normal = dict()
         self.user = None
+        self.geometry = None
+        if geometry is not None:
+            self.geometry = geometry
 
     def __str__(self):
         return "TODO: Print for DiscreteGeometry"
@@ -102,3 +105,7 @@ class GeometryDiscrete:
             subp.user = self.user[s:e, :]
 
         return subp
+
+    def boundary_encryption(self, name, dist, npoints):
+        # record the message 
+        self.encryption[name] = Encryption(dist, npoints)

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -96,7 +96,7 @@ class Rectangular(Geometry):
         geo = geo.pv_mesh
 
         if geo.is_manifold is False and geo.is_all_triangles is False:
-            assert 0, "The mesh must be manifold and need to be a Triangulate mesh."
+            assert 0, "The mesh must be watertight and need to be a Triangulate mesh."
 
         faces_as_array = geo.faces.reshape((geo.n_faces, 4))[:, 1:]
 

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -96,7 +96,7 @@ class Rectangular(Geometry):
         geo = geo.pv_mesh
 
         if geo.is_manifold is False and geo.is_all_triangles is False:
-            assert 0, "The mesh must be manifold and need to be triangulate."
+            assert 0, "The mesh must be manifold and need to be a Triangulate mesh."
 
         faces_as_array = geo.faces.reshape((geo.n_faces, 4))[:, 1:]
 

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -96,10 +96,11 @@ class Rectangular(Geometry):
                 self.encryption[name].get_npoints(), self.tri_mesh[name])
             encryption_total_points.append(encryption_points)
 
-        encryption_total_points = np.vstack(encryption_total_points)
-        result = np.concatenate((points, encryption_total_points), axis=0)
+        if len(encryption_total_points) > 0:
+            encryption_total_points = np.vstack(encryption_total_points)
+            points = np.concatenate((points, encryption_total_points), axis=0)
 
-        return super(Rectangular, self)._mesh_to_geo_disc(result, padding)
+        return super(Rectangular, self)._mesh_to_geo_disc(points, padding)
 
     def _sampling_encryption(self, dist, npoints, geo=None):
         # construct the sdf of the geo

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -89,18 +89,19 @@ class Rectangular(Geometry):
             assert 0, "The discretize method can only be uniform, sampling or quasi sampler."
 
         # generate encryption points.
-        encryption_total_points = []
-        for name in self.encryption.keys():
-            encryption_points = self._sampling_encryption(
-                self.encryption[name].get_dist(),
-                self.encryption[name].get_npoints(), self.tri_mesh[name])
-            encryption_total_points.append(encryption_points)
+        # encryption_total_points = []
+        # for name in self.encryption.keys():
+        #     encryption_points = self._sampling_encryption(
+        #         self.encryption[name].get_dist(),
+        #         self.encryption[name].get_npoints(), self.tri_mesh[name])
+        #     encryption_total_points.append(encryption_points)
 
-        if len(encryption_total_points) > 0:
-            encryption_total_points = np.vstack(encryption_total_points)
-            points = np.concatenate((points, encryption_total_points), axis=0)
+        # if len(encryption_total_points) > 0:
+        #     encryption_total_points = np.vstack(encryption_total_points)
+        #     points = np.concatenate((points, encryption_total_points), axis=0)
 
-        return super(Rectangular, self)._mesh_to_geo_disc(points, padding)
+        return super(Rectangular, self)._mesh_to_geo_disc(points, padding,
+                                                          npoints)
 
     def _sampling_encryption(self, dist, npoints, geo=None):
         # construct the sdf of the geo

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -88,22 +88,10 @@ class Rectangular(Geometry):
         else:
             assert 0, "The discretize method can only be uniform, sampling or quasi sampler."
 
-        # generate encryption points.
-        # encryption_total_points = []
-        # for name in self.encryption.keys():
-        #     encryption_points = self._sampling_encryption(
-        #         self.encryption[name].get_dist(),
-        #         self.encryption[name].get_npoints(), self.tri_mesh[name])
-        #     encryption_total_points.append(encryption_points)
-
-        # if len(encryption_total_points) > 0:
-        #     encryption_total_points = np.vstack(encryption_total_points)
-        #     points = np.concatenate((points, encryption_total_points), axis=0)
-
         return super(Rectangular, self)._mesh_to_geo_disc(points, padding,
                                                           npoints)
 
-    def _sampling_encryption(self, dist, npoints, geo=None):
+    def _sampling_refinement(self, dist, npoints, geo=None):
         # construct the sdf of the geo
         geo = geo.pv_mesh
 

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -87,6 +87,8 @@ class Rectangular(Geometry):
         else:
             assert 0, "The discretize method can only be uniform, sampling or quasi sampler."
 
+        #TODO
+
         return super(Rectangular, self)._mesh_to_geo_disc(points, padding)
 
     def _sampling_boundary(self, npoints):

--- a/paddlescience/geometry/rectangular.py
+++ b/paddlescience/geometry/rectangular.py
@@ -88,12 +88,16 @@ class Rectangular(Geometry):
         else:
             assert 0, "The discretize method can only be uniform, sampling or quasi sampler."
 
-        #TODO
-        # phase 1. sampler interior points
-        encryption_points = self._sampling_encryption(
-            1, 200000, self.tri_mesh['triangle'])
+        # generate encryption points.
+        encryption_total_points = []
+        for name in self.encryption.keys():
+            encryption_points = self._sampling_encryption(
+                self.encryption[name].get_dist(),
+                self.encryption[name].get_npoints(), self.tri_mesh[name])
+            encryption_total_points.append(encryption_points)
 
-        result = np.concatenate((points, encryption_points), axis=0)
+        encryption_total_points = np.vstack(encryption_total_points)
+        result = np.concatenate((points, encryption_total_points), axis=0)
 
         return super(Rectangular, self)._mesh_to_geo_disc(result, padding)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Boundary refinement.

功能描述：增加了局部加密的API接口，使用示例如下：
```
import paddlescience as psci
import numpy as np
import paddle

# triangle
vertices = np.array([[3, 3, 0], [7, 3, 0], 
            [5, 7, 0], [3, 3, 0.5], 
            [7, 3, 0.5], [5, 7, 0.5]])
# mesh faces 
# Right-hand rule
faces = np.hstack(
    [
        [3, 0, 2, 1],  # triangle
        [3, 3, 4, 5],  # triangle
        [4, 0, 3, 5, 2], # square
        [4, 1, 2, 5, 4], # square
        [4, 0, 1, 4, 3],  # square
    ]
)

triangle = psci.geometry.PolyData(vertices, faces)

geo = psci.geometry.Rectangular(origin=(0, 0, 0), extent=(10, 10, 0.5))

geo = geo - triangle

geo.add_boundary(name="inlet", criteria=lambda x, y, z: abs(x) < 1e-5)
geo.add_boundary(name="outlet", criteria=lambda x, y, z: abs(x - 10) < 1e-5)
geo.add_boundary(name="triangle", filename=triangle)

# discretize geometry
geo_disc = geo.discretize(method="quasi_sobol", npoints= 3000)
geo_disc = geo_disc.boundary_refinement(name="triangle", dist=1, npoints=20000)

psci.visu.save_vtk(filename="out", geo_disc=geo_disc)
```
生成的结果用Paraview打开如下：
![image](https://user-images.githubusercontent.com/85323580/183383588-23b769b8-0a7c-4b1a-8770-3e8b84a6ad1e.png)
