### PR TITLE
move timing position ahead of training

### DIFF
--- a/paddlescience/solver/solver.py
+++ b/paddlescience/solver/solver.py
@@ -641,6 +641,8 @@ class Solver(object):
         # dataset
         train_dataset = DataSetStatic(num_epoch, inputs + labels)
 
+        timer = utils.Timer()
+
         # train
         self.engine.fit(train_dataset, len(inputs + labels), batch_size=None)
 
@@ -670,8 +672,6 @@ class Solver(object):
         fetches = []
         for out in self.outs_predict:
             fetches.append(out.name)
-
-        timer = utils.Timer()
 
         rslt = self.engine._executor.run(self.predict_auto_dist_program,
                                          feed=feeds,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
Bug fixes

### PR changes
APIs 

### Describe
修复了多卡自动并行机制下，开始计时位置不正确的问题
