### PR TITLE
Fix requirement for pyvista

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pandas
 wget
 scipy
 visualdl
-pyvista
+pyvista==0.37.0
 pysdf
 pyyaml


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
Bug fixes

### PR changes
Requirements

### Describe
Fix `pyvista==0.37.0`, for 0.38.0 is not stable and will cause error during installion.
