### PR TITLE
remove with_data_parallel

### DIFF
--- a/paddlescience/solver/utils.py
+++ b/paddlescience/solver/utils.py
@@ -228,8 +228,7 @@ def compile_and_convert_back_to_program(program=None,
         build_strategy = paddle.static.BuildStrategy()
 
         compiled_program = paddle.static.CompiledProgram(
-            program,
-            build_strategy=build_strategy)
+            program, build_strategy=build_strategy)
 
         return compiled_program
 

--- a/paddlescience/solver/utils.py
+++ b/paddlescience/solver/utils.py
@@ -226,15 +226,10 @@ def compile_and_convert_back_to_program(program=None,
 
     def _compile(program, loss_name=None):
         build_strategy = paddle.static.BuildStrategy()
-        exec_strategy = paddle.static.ExecutionStrategy()
-
-        exec_strategy.num_threads = 1
 
         compiled_program = paddle.static.CompiledProgram(
-            program).with_data_parallel(
-                loss_name=loss_name,
-                build_strategy=build_strategy,
-                exec_strategy=exec_strategy)
+            program,
+            build_strategy=build_strategy)
 
         return compiled_program
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
`with_data_parallel`预计于paddle2.5版本移除。此处是为了开启`build_cinn_pass`，paddle develop分支现在已经支持不使用`with_data_parallel`就打开`build_cinn_pass`，因此直接移除了这里对`with_data_parallel`的使用。


The api `with_data_parallel` will be deprecated in paddle2.5. The purpose of `with_data_parallel` here is to `build_cinn_pass`. howerver, such operation doesn't need to use `with_data_parallel` with current `paddle`(develop). So just delete it.