### PR TITLE
Add ldc2d unsteady re10 case

### DIFF
--- a/examples/ldc/ldc2d_steady_Re10.py
+++ b/examples/ldc/ldc2d_steady_Re10.py
@@ -1,0 +1,178 @@
+"""Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+
+import ppsci
+
+if __name__ == "__main__":
+    ppsci.utils.misc.set_random_seed(42)
+    model = ppsci.arch.MLP(["x", "y"], ["u", "v", "p"], 9, 50, "tanh", False, False)
+    equation = {"NavierStokes": ppsci.equation.NavierStokes(0.01, 1.0, 2, False)}
+    geom = {"rect": ppsci.geometry.Rectangle([-0.05, -0.05], [0.05, 0.05])}
+    iters_per_epoch = 1
+    constraint = {
+        "EQ": ppsci.constraint.InteriorConstraint(
+            equation["NavierStokes"].equations,
+            {"continuity": 0, "momentum_x": 0, "momentum_y": 0},
+            geom["rect"],
+            {
+                "dataset": "IterableNamedArrayDataset",
+                "iters_per_epoch": iters_per_epoch,
+                "batch_size": 9801,
+                "num_workers": 2,
+                "seed": 42,
+                "use_shared_memory": False,
+            },
+            ppsci.loss.MSELoss("sum"),
+            evenly=True,
+            weight_dict={
+                "continuity": 0.0001,
+                "momentum_x": 0.0001,
+                "momentum_y": 0.0001,
+            },
+            name="EQ",
+        ),
+        "BC_top": ppsci.constraint.BoundaryConstraint(
+            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+            {"u": 1.0, "v": 0.0},
+            geom["rect"],
+            {
+                "dataset": "IterableNamedArrayDataset",
+                "iters_per_epoch": iters_per_epoch,
+                "batch_size": 101,
+                "num_workers": 1,
+                "seed": 42,
+                "use_shared_memory": False,
+            },
+            ppsci.loss.MSELoss("sum"),
+            criteria=lambda x, y: np.isclose(y, 0.05),
+            weight_dict={"u": lambda input: 1.0 - 20.0 * input["x"]},
+            name="BC_top",
+        ),
+        "BC_down": ppsci.constraint.BoundaryConstraint(
+            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+            {"u": 0.0, "v": 0.0},
+            geom["rect"],
+            {
+                "dataset": "IterableNamedArrayDataset",
+                "iters_per_epoch": iters_per_epoch,
+                "batch_size": 101,
+                "num_workers": 1,
+                "seed": 42,
+                "use_shared_memory": False,
+            },
+            ppsci.loss.MSELoss("sum"),
+            criteria=lambda x, y: np.isclose(y, -0.05),
+            name="BC_down",
+        ),
+        "BC_left": ppsci.constraint.BoundaryConstraint(
+            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+            {"u": 0.0, "v": 0.0},
+            geom["rect"],
+            {
+                "dataset": "IterableNamedArrayDataset",
+                "iters_per_epoch": iters_per_epoch,
+                "batch_size": 99,
+                "num_workers": 1,
+                "seed": 42,
+                "use_shared_memory": False,
+            },
+            ppsci.loss.MSELoss("sum"),
+            criteria=lambda x, y: np.isclose(x, -0.05),
+            name="BC_left",
+        ),
+        "BC_right": ppsci.constraint.BoundaryConstraint(
+            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+            {"u": 0.0, "v": 0.0},
+            geom["rect"],
+            {
+                "dataset": "IterableNamedArrayDataset",
+                "iters_per_epoch": iters_per_epoch,
+                "batch_size": 99,
+                "num_workers": 1,
+                "seed": 42,
+                "use_shared_memory": False,
+            },
+            ppsci.loss.MSELoss("sum"),
+            criteria=lambda x, y: np.isclose(x, 0.05),
+            name="BC_right",
+        ),
+    }
+    epochs = 20000
+    lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(
+        epochs,
+        iters_per_epoch,
+        0.001,
+        warmup_epoch=int(0.05 * epochs),
+    )()
+    optimizer = ppsci.optimizer.Adam(lr_scheduler)([model])
+
+    validator = {
+        "Residual": ppsci.validate.GeometryValidator(
+            equation["NavierStokes"].equations,
+            {
+                "momentum_x": 0,
+                "continuity": 0,
+                "momentum_y": 0,
+                "u": 0.0,
+                "v": 0.0,
+                "p": 0.0,
+            },
+            geom["rect"],
+            {
+                "dataset": "IterableNamedArrayDataset",
+                "total_size": 9801,
+                "num_workers": 0,
+                "seed": 42,
+                "use_shared_memory": False,
+            },
+            ppsci.loss.MSELoss("sum"),
+            evenly=True,
+            metric={"MSE": ppsci.metric.MSE()},
+            name="Residual",
+        )
+    }
+
+    output_dir = "./ldc2d_steady_Re10"
+    train_solver = ppsci.solver.Solver(
+        "train",
+        model,
+        constraint,
+        output_dir,
+        optimizer,
+        lr_scheduler,
+        epochs,
+        iters_per_epoch,
+        eval_during_train=True,
+        eval_freq=200,
+        equation=equation,
+        geom=geom,
+        validator=validator,
+    )
+    train_solver.train()
+
+    # evaluate the final checkpoint
+    eval_solver = ppsci.solver.Solver(
+        "eval",
+        model,
+        constraint,
+        output_dir,
+        equation=equation,
+        geom=geom,
+        validator=validator,
+        pretrained_model=f"./{output_dir}/checkpoints/epoch_{epochs}",
+    )
+    eval_solver.eval()

--- a/examples/ldc/ldc2d_unsteady_Re10.py
+++ b/examples/ldc/ldc2d_unsteady_Re10.py
@@ -18,106 +18,115 @@ import numpy as np
 import ppsci
 
 if __name__ == "__main__":
+    # set random seed for reproducibility
     ppsci.utils.misc.set_random_seed(42)
+    # set output directory
+    output_dir = "./ldc2d_unsteady_Re10"
+
+    # set model
     model = ppsci.arch.MLP(
         ["t", "x", "y"], ["u", "v", "p"], 9, 50, "tanh", False, False
     )
+    # set equation
     equation = {"NavierStokes": ppsci.equation.NavierStokes(0.01, 1.0, 2, True)}
+
+    # timestamps including initial t0
+    timestamps = np.linspace(0.0, 1.5, 16, endpoint=True)
+    # set time-eometry
     geom = {
         "time_rect": ppsci.geometry.TimeXGeometry(
-            ppsci.geometry.TimeDomain(
-                0.0, 1.5, timestamps=np.linspace(0.0, 1.5, 16, endpoint=True)
-            ),
+            ppsci.geometry.TimeDomain(0.0, 1.5, timestamps=timestamps),
             ppsci.geometry.Rectangle([-0.05, -0.05], [0.05, 0.05]),
         )
     }
+
+    # set dataloader config
     iters_per_epoch = 1
-    constraint = {
-        "EQ": ppsci.constraint.InteriorConstraint(
-            equation["NavierStokes"].equations,
-            {"continuity": 0, "momentum_x": 0, "momentum_y": 0},
-            geom["time_rect"],
-            {
-                "dataset": "IterableNamedArrayDataset",
-                "iters_per_epoch": iters_per_epoch,
-                "batch_size": 9801 * 15,
-            },
-            ppsci.loss.MSELoss("sum"),
-            evenly=True,
-            weight_dict={
-                "continuity": 0.0001,
-                "momentum_x": 0.0001,
-                "momentum_y": 0.0001,
-            },
-            name="EQ",
-        ),
-        "BC_top": ppsci.constraint.BoundaryConstraint(
-            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
-            {"u": 1.0, "v": 0.0},
-            geom["time_rect"],
-            {
-                "dataset": "IterableNamedArrayDataset",
-                "iters_per_epoch": iters_per_epoch,
-                "batch_size": 101 * 15,
-            },
-            ppsci.loss.MSELoss("sum"),
-            criteria=lambda t, x, y: np.isclose(y, 0.05),
-            weight_dict={"u": lambda input: 1.0 - 20.0 * input["x"]},
-            name="BC_top",
-        ),
-        "BC_down": ppsci.constraint.BoundaryConstraint(
-            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
-            {"u": 0.0, "v": 0.0},
-            geom["time_rect"],
-            {
-                "dataset": "IterableNamedArrayDataset",
-                "iters_per_epoch": iters_per_epoch,
-                "batch_size": 101 * 15,
-            },
-            ppsci.loss.MSELoss("sum"),
-            criteria=lambda t, x, y: np.isclose(y, -0.05),
-            name="BC_down",
-        ),
-        "BC_left": ppsci.constraint.BoundaryConstraint(
-            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
-            {"u": 0.0, "v": 0.0},
-            geom["time_rect"],
-            {
-                "dataset": "IterableNamedArrayDataset",
-                "iters_per_epoch": iters_per_epoch,
-                "batch_size": 99 * 15,
-            },
-            ppsci.loss.MSELoss("sum"),
-            criteria=lambda t, x, y: np.isclose(x, -0.05),
-            name="BC_left",
-        ),
-        "BC_right": ppsci.constraint.BoundaryConstraint(
-            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
-            {"u": 0.0, "v": 0.0},
-            geom["time_rect"],
-            {
-                "dataset": "IterableNamedArrayDataset",
-                "iters_per_epoch": iters_per_epoch,
-                "batch_size": 99 * 15,
-            },
-            ppsci.loss.MSELoss("sum"),
-            criteria=lambda t, x, y: np.isclose(x, 0.05),
-            name="BC_right",
-        ),
-        "IC": ppsci.constraint.InitialConstraint(
-            {"u": lambda out: out["u"], "v": lambda out: out["v"]},
-            {"u": 0.0, "v": 0.0},
-            geom["time_rect"],
-            {
-                "dataset": "IterableNamedArrayDataset",
-                "iters_per_epoch": iters_per_epoch,
-                "batch_size": 9801,
-            },
-            ppsci.loss.MSELoss("sum"),
-            evenly=True,
-            name="IC",
-        ),
+    train_dataloader_cfg = {
+        "dataset": "IterableNamedArrayDataset",
+        "iters_per_epoch": iters_per_epoch,
     }
+
+    # pde/bc constraint use t1~tn, initial constraint use t0
+    ntime_all = len(timestamps)
+    npoint_pde, ntime_pde = 9801, ntime_all - 1
+    npoint_top, ntime_top = 101, ntime_all - 1
+    npoint_down, ntime_down = 101, ntime_all - 1
+    npoint_left, ntime_left = 99, ntime_all - 1
+    npoint_right, ntime_right = 99, ntime_all - 1
+    npoint_ic, ntime_ic = 9801, 1
+
+    # set constraint
+    pde_constraint = ppsci.constraint.InteriorConstraint(
+        equation["NavierStokes"].equations,
+        {"continuity": 0, "momentum_x": 0, "momentum_y": 0},
+        geom["time_rect"],
+        {**train_dataloader_cfg, **{"batch_size": npoint_pde * ntime_pde}},
+        ppsci.loss.MSELoss("sum"),
+        evenly=True,
+        weight_dict={
+            "continuity": 0.0001,
+            "momentum_x": 0.0001,
+            "momentum_y": 0.0001,
+        },
+        name="EQ",
+    )
+    bc_top = ppsci.constraint.BoundaryConstraint(
+        {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+        {"u": 1, "v": 0},
+        geom["time_rect"],
+        {**train_dataloader_cfg, **{"batch_size": npoint_top * ntime_top}},
+        ppsci.loss.MSELoss("sum"),
+        criteria=lambda t, x, y: np.isclose(y, 0.05),
+        weight_dict={"u": lambda input: 1 - 20 * input["x"]},
+        name="BC_top",
+    )
+    bc_down = ppsci.constraint.BoundaryConstraint(
+        {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+        {"u": 0, "v": 0},
+        geom["time_rect"],
+        {**train_dataloader_cfg, **{"batch_size": npoint_down * ntime_down}},
+        ppsci.loss.MSELoss("sum"),
+        criteria=lambda t, x, y: np.isclose(y, -0.05),
+        name="BC_down",
+    )
+    bc_left = ppsci.constraint.BoundaryConstraint(
+        {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+        {"u": 0, "v": 0},
+        geom["time_rect"],
+        {**train_dataloader_cfg, **{"batch_size": npoint_left * ntime_left}},
+        ppsci.loss.MSELoss("sum"),
+        criteria=lambda t, x, y: np.isclose(x, -0.05),
+        name="BC_left",
+    )
+    bc_right = ppsci.constraint.BoundaryConstraint(
+        {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+        {"u": 0, "v": 0},
+        geom["time_rect"],
+        {**train_dataloader_cfg, **{"batch_size": npoint_right * ntime_right}},
+        ppsci.loss.MSELoss("sum"),
+        criteria=lambda t, x, y: np.isclose(x, 0.05),
+        name="BC_right",
+    )
+    ic = ppsci.constraint.InitialConstraint(
+        {"u": lambda out: out["u"], "v": lambda out: out["v"]},
+        {"u": 0, "v": 0},
+        geom["time_rect"],
+        {**train_dataloader_cfg, **{"batch_size": npoint_ic * ntime_ic}},
+        ppsci.loss.MSELoss("sum"),
+        evenly=True,
+        name="IC",
+    )
+    constraint = {
+        pde_constraint.name: pde_constraint,
+        bc_top.name: bc_top,
+        bc_down.name: bc_down,
+        bc_left.name: bc_left,
+        bc_right.name: bc_right,
+        ic.name: ic,
+    }
+
+    # set training hyper-parameters
     epochs = 20000
     lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(
         epochs,
@@ -125,33 +134,72 @@ if __name__ == "__main__":
         0.001,
         warmup_epoch=int(0.05 * epochs),
     )()
+
+    # set optimizer
     optimizer = ppsci.optimizer.Adam(lr_scheduler)([model])
 
-    validator = {
-        "Residual": ppsci.validate.GeometryValidator(
-            equation["NavierStokes"].equations,
-            {
-                "momentum_x": 0,
-                "continuity": 0,
-                "momentum_y": 0,
-                "u": 0.0,
-                "v": 0.0,
-                "p": 0.0,
-            },
-            geom["time_rect"],
-            {
-                "dataset": "IterableNamedArrayDataset",
-                "total_size": 9801 * 16,
-            },
-            ppsci.loss.MSELoss("sum"),
-            evenly=True,
-            metric={"MSE": ppsci.metric.MSE()},
-            with_initial=True,
-            name="Residual",
+    # set validator
+    npoints_eval = npoint_pde * ntime_all
+    residual_validator = ppsci.validate.GeometryValidator(
+        equation["NavierStokes"].equations,
+        {"momentum_x": 0, "continuity": 0, "momentum_y": 0},
+        geom["time_rect"],
+        {
+            "dataset": "NamedArrayDataset",
+            "total_size": npoints_eval,
+            "batch_size": 8192,
+            "sampler": {"name": "BatchSampler"},
+        },
+        ppsci.loss.MSELoss("sum"),
+        evenly=True,
+        metric={"MSE": ppsci.metric.MSE()},
+        with_initial=True,
+        name="Residual",
+    )
+    validator = {residual_validator.name: residual_validator}
+
+    # set visualizer(optional)
+    npoint_bc = npoint_top + npoint_down + npoint_left + npoint_right
+    ntime_bc = ntime_top
+    vis_initial_points = geom["time_rect"].sample_initial_interior(
+        npoint_ic, evenly=True
+    )
+    vis_interior_points = geom["time_rect"].sample_interior(
+        npoint_pde * ntime_pde, evenly=True
+    )
+    vis_boundary_points = geom["time_rect"].sample_boundary(
+        npoint_bc * ntime_bc, evenly=True
+    )
+
+    # concatenate interior points with boundary points
+    vis_initial_points = {
+        key: np.concatenate(
+            (vis_initial_points[key], vis_boundary_points[key][:npoint_bc])
+        )
+        for key in vis_initial_points
+    }
+
+    vis_points = vis_initial_points
+    for t in range(ntime_pde):
+        for key in vis_interior_points:
+            vis_points[key] = np.concatenate(
+                (
+                    vis_points[key],
+                    vis_interior_points[key][t * npoint_pde : (t + 1) * npoint_pde],
+                    vis_boundary_points[key][t * npoint_bc : (t + 1) * npoint_bc],
+                )
+            )
+
+    visualizer = {
+        "visulzie_u_v": ppsci.visualize.VisualizerVtu(
+            vis_points,
+            {"u": lambda d: d["u"], "v": lambda d: d["v"], "p": lambda d: d["p"]},
+            ntime_all,
+            "result_u_v",
         )
     }
 
-    output_dir = "./ldc2d_unsteady_Re10"
+    # initialize train solver
     train_solver = ppsci.solver.Solver(
         "train",
         model,
@@ -166,7 +214,9 @@ if __name__ == "__main__":
         equation=equation,
         geom=geom,
         validator=validator,
+        visualizer=visualizer,
     )
+    # train model
     train_solver.train()
 
     # evaluate the final checkpoint
@@ -178,6 +228,9 @@ if __name__ == "__main__":
         equation=equation,
         geom=geom,
         validator=validator,
-        pretrained_model=f"./{output_dir}/checkpoints/epoch_{epochs}",
+        visualizer=visualizer,
+        pretrained_model_path=f"{output_dir}/checkpoints/latest",
     )
     eval_solver.eval()
+
+    eval_solver.visualize()

--- a/ppsci/__init__.py
+++ b/ppsci/__init__.py
@@ -13,32 +13,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from ppsci import arch
-from ppsci import autodiff
-from ppsci import constraint
-from ppsci import data
-from ppsci import equation
-from ppsci import geometry
-from ppsci import loss
-from ppsci import metric
-from ppsci import optimizer
-from ppsci import solver
-from ppsci import utils
-from ppsci import validate
-from ppsci import visualize
+from ppsci import arch  # isort:skip
+from ppsci import autodiff  # isort:skip
+from ppsci import constraint  # isort:skip
+from ppsci import data  # isort:skip
+from ppsci import equation  # isort:skip
+from ppsci import geometry  # isort:skip
+from ppsci import loss  # isort:skip
+from ppsci import metric  # isort:skip
+from ppsci import optimizer  # isort:skip
+from ppsci import utils  # isort:skip
+from ppsci import visualize  # isort:skip
+from ppsci import validate  # isort:skip
+from ppsci import solver  # isort:skip
 
 __all__ = [
     "arch",
+    "autodiff",
     "constraint",
     "data",
     "equation",
     "geometry",
-    "autodiff",
     "loss",
     "metric",
     "optimizer",
-    "solver",
     "utils",
-    "validate",
     "visualize",
+    "validate",
+    "solver",
 ]

--- a/ppsci/constraint/boundary_constraint.py
+++ b/ppsci/constraint/boundary_constraint.py
@@ -73,7 +73,7 @@ class BoundaryConstraint(base.Constraint):
             criteria = eval(criteria)
 
         input = geom.sample_boundary(
-            dataloader_cfg["sampler"]["batch_size"] * dataloader_cfg["iters_per_epoch"],
+            dataloader_cfg["batch_size"] * dataloader_cfg["iters_per_epoch"],
             random,
             criteria,
             evenly,

--- a/ppsci/constraint/initial_constraint.py
+++ b/ppsci/constraint/initial_constraint.py
@@ -68,7 +68,7 @@ class InitialConstraint(base.Constraint):
             criteria = eval(criteria)
 
         input = geom.sample_initial_interior(
-            dataloader_cfg["sampler"]["batch_size"] * dataloader_cfg["iters_per_epoch"],
+            dataloader_cfg["batch_size"] * dataloader_cfg["iters_per_epoch"],
             random,
             criteria,
             evenly,

--- a/ppsci/constraint/integral_constraint.py
+++ b/ppsci/constraint/integral_constraint.py
@@ -76,7 +76,7 @@ class IntegralConstraint(base.Constraint):
         # integral sample
         input_list = []
         for _ in range(
-            dataloader_cfg["sampler"]["batch_size"] * dataloader_cfg["iters_per_epoch"]
+            dataloader_cfg["batch_size"] * dataloader_cfg["iters_per_epoch"]
         ):
             input = geom.sample_boundary(
                 dataloader_cfg["integral_batch_size"], random, criteria, evenly

--- a/ppsci/constraint/interior_constraint.py
+++ b/ppsci/constraint/interior_constraint.py
@@ -73,7 +73,7 @@ class InteriorConstraint(base.Constraint):
             criteria = eval(criteria)
 
         input = geom.sample_interior(
-            dataloader_cfg["sampler"]["batch_size"] * dataloader_cfg["iters_per_epoch"],
+            dataloader_cfg["batch_size"] * dataloader_cfg["iters_per_epoch"],
             random,
             criteria,
             evenly,

--- a/ppsci/data/dataset/__init__.py
+++ b/ppsci/data/dataset/__init__.py
@@ -14,11 +14,12 @@ limitations under the License.
 """
 import copy
 
+from ppsci.data.dataset.array_dataset import IterableNamedArrayDataset
 from ppsci.data.dataset.array_dataset import NamedArrayDataset
 from ppsci.data.process import transform
 from ppsci.utils import logger
 
-__all__ = ["NamedArrayDataset", "build_dataset"]
+__all__ = ["IterableNamedArrayDataset", "NamedArrayDataset", "build_dataset"]
 
 
 def build_dataset(cfg):

--- a/ppsci/data/dataset/array_dataset.py
+++ b/ppsci/data/dataset/array_dataset.py
@@ -13,11 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import paddle
 from paddle import io
 
 
 class NamedArrayDataset(io.Dataset):
-    """Class for Named Array Dataset
+    """Class for Named Array Dataset.
 
     Args:
         input (Dict[str, np.ndarray]): Input dict.
@@ -47,3 +48,32 @@ class NamedArrayDataset(io.Dataset):
 
     def __len__(self):
         return self._len
+
+
+class IterableNamedArrayDataset(io.IterableDataset):
+    """IterableNamedArrayDataset for full-data training, i.e.batch_size=len(data).
+
+    Args:
+        input (Dict[str, np.ndarray]): Input dict.
+        label (Dict[str, np.ndarray]): Label dict.
+        weight (Dict[str, np.ndarray]): Weight dict.
+        batch_size (int): Batch size. Defaults to None.
+        transforms (vision.Compose, optional): Compose object contains sample wise transform(s). Defaults to None.
+    """
+
+    def __init__(self, input, label, weight, transforms=None):
+        self.input = {k: paddle.to_tensor(v) for k, v in input.items()}
+        self.label = {k: paddle.to_tensor(v) for k, v in label.items()}
+        self.weight = {k: paddle.to_tensor(v) for k, v in weight.items()}
+        self._len = len(next(iter(self.input.values())))
+
+    @property
+    def num_samples(self):
+        """Number of samples within current dataset."""
+        return self._len
+
+    def __iter__(self):
+        yield self.input, self.label, self.weight
+
+    def __len__(self):
+        return 1

--- a/ppsci/equation/pde/navier_stokes.py
+++ b/ppsci/equation/pde/navier_stokes.py
@@ -99,18 +99,15 @@ class NavierStokes(base.PDE):
                 momentum_z = (
                     u * jacobian(w, x)
                     + v * jacobian(w, y)
+                    + w * jacobian(w, z)
                     - nu / rho * hessian(w, x)
                     - nu / rho * hessian(w, y)
+                    - nu / rho * hessian(w, z)
                     + 1 / rho * jacobian(p, z)
                 )
                 if self.time:
                     t = out["t"]
                     momentum_z += jacobian(w, t)
-                if self.dim == 3:
-                    z = out["z"]
-                    w = out["w"]
-                    momentum_z += w * jacobian(w, z)
-                    momentum_z -= nu / rho * hessian(w, z)
                 return momentum_z
 
             self.add_equation("momentum_z", momentum_z_compute_func)

--- a/ppsci/geometry/geometry.py
+++ b/ppsci/geometry/geometry.py
@@ -197,7 +197,7 @@ class Geometry(object):
 
     def __str__(self) -> str:
         """Return the name of class"""
-        _str = ", ".join(
+        return ", ".join(
             [
                 self.__class__.__name__,
                 f"ndim = {self.ndim}",
@@ -206,4 +206,3 @@ class Geometry(object):
                 f"dim_keys = {self.dim_keys}",
             ]
         )
-        return _str

--- a/ppsci/geometry/geometry.py
+++ b/ppsci/geometry/geometry.py
@@ -62,7 +62,10 @@ class Geometry(object):
             if evenly:
                 points = self.uniform_points(n)
             else:
-                points = self.random_points(n, random)
+                if misc.typename(self) == "TimeXGeometry":
+                    points = self.random_points(n, random, criteria)
+                else:
+                    points = self.random_points(n, random)
 
             if criteria is not None:
                 criteria_mask = criteria(*np.split(points, self.ndim, axis=1)).flatten()
@@ -91,9 +94,9 @@ class Geometry(object):
                     misc.typename(self) == "TimeXGeometry"
                     and misc.typename(self.geometry) == "Mesh"
                 ):
-                    points, normal, area = self.uniform_boundary_points(n, True)
+                    points, normal, area = self.uniform_boundary_points(n)
                 else:
-                    points = self.uniform_boundary_points(n, True)
+                    points = self.uniform_boundary_points(n)
             else:
                 if (
                     misc.typename(self) == "TimeXGeometry"
@@ -101,7 +104,10 @@ class Geometry(object):
                 ):
                     points, normal, area = self.random_boundary_points(n, random)
                 else:
-                    points = self.random_boundary_points(n, random)
+                    if misc.typename(self) == "TimeXGeometry":
+                        points = self.random_boundary_points(n, random, criteria)
+                    else:
+                        points = self.random_boundary_points(n, random)
 
             if criteria is not None:
                 criteria_mask = criteria(*np.split(points, self.ndim, axis=1)).flatten()

--- a/ppsci/geometry/mesh.py
+++ b/ppsci/geometry/mesh.py
@@ -384,7 +384,7 @@ class Mesh(geometry.Geometry):
 
     def __str__(self) -> str:
         """Return the name of class"""
-        _str = ", ".join(
+        return ", ".join(
             [
                 self.__class__.__name__,
                 f"num_vertices = {self.num_vertices}",
@@ -393,7 +393,6 @@ class Mesh(geometry.Geometry):
                 f"dim_keys = {self.dim_keys}",
             ]
         )
-        return _str
 
 
 def area_of_triangles(v0, v1, v2):

--- a/ppsci/geometry/pointcloud.py
+++ b/ppsci/geometry/pointcloud.py
@@ -50,7 +50,7 @@ class PointCloud(geometry.Geometry):
             self.interior = np.concatenate(self.interior, -1)
 
         # PointCloud from CSV file
-        if boundary_path is not None and boundary_path.endswith(".csv"):
+        if boundary_path is not None:
             # read data
             data_dict = misc.load_csv_file(boundary_path, coord_keys)
 
@@ -63,7 +63,7 @@ class PointCloud(geometry.Geometry):
             self.boundary = None
 
         # PointCloud from CSV file
-        if boundary_normal_path is not None and boundary_normal_path.endswith(".csv"):
+        if boundary_normal_path is not None:
             # read data
             data_dict = misc.load_csv_file(boundary_normal_path, coord_keys)
 
@@ -191,7 +191,7 @@ class PointCloud(geometry.Geometry):
 
     def __str__(self) -> str:
         """Return the name of class"""
-        _str = ", ".join(
+        return ", ".join(
             [
                 self.__class__.__name__,
                 f"num_points = {len(self.interior)}",
@@ -200,4 +200,3 @@ class PointCloud(geometry.Geometry):
                 f"dim_keys = {self.dim_keys}",
             ]
         )
-        return _str

--- a/ppsci/solver/__init__.py
+++ b/ppsci/solver/__init__.py
@@ -15,16 +15,12 @@ limitations under the License.
 
 from ppsci.solver import eval
 from ppsci.solver import train
-from ppsci.solver.eval import eval_func
+from ppsci.solver import visu
 from ppsci.solver.solver import Solver
-from ppsci.solver.train import train_epoch_func
-from ppsci.solver.train import train_LBFGS_epoch_func
 
 __all__ = [
     "eval",
     "train",
-    "eval_func",
+    "visu",
     "Solver",
-    "train_epoch_func",
-    "train_LBFGS_epoch_func",
 ]

--- a/ppsci/solver/eval.py
+++ b/ppsci/solver/eval.py
@@ -19,6 +19,7 @@ import time
 
 import paddle
 import paddle.amp as amp
+import paddle.io as io
 
 from ppsci import visualize
 from ppsci.solver import printer
@@ -43,7 +44,10 @@ def eval_func(solver, epoch_id, log_freq):
         all_input = misc.Prettydefaultdict(list)
         all_output = misc.Prettydefaultdict(list)
         all_label = misc.Prettydefaultdict(list)
-        num_samples = len(_validator.data_loader.dataset)
+        if isinstance(_validator.data_loader, io.DataLoader):
+            num_samples = len(_validator.data_loader.dataset)
+        else:
+            num_samples = _validator.data_loader.num_samples
 
         loss_dict = misc.Prettydefaultdict(float)
         reader_tic = time.perf_counter()
@@ -52,7 +56,7 @@ def eval_func(solver, epoch_id, log_freq):
             input_dict, label_dict, _ = batch
 
             # profile code
-            profiler.add_profiler_step(solver.cfg["profiler_options"])
+            # profiler.add_profiler_step(solver.cfg["profiler_options"])
             if iter_id == 5:
                 # 5 step for warmup
                 for key in solver.eval_time_info:

--- a/ppsci/solver/eval.py
+++ b/ppsci/solver/eval.py
@@ -13,15 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
-import os.path as osp
 import time
 
 import paddle
 import paddle.amp as amp
 import paddle.io as io
 
-from ppsci import visualize
 from ppsci.solver import printer
 from ppsci.utils import expression
 from ppsci.utils import misc
@@ -153,16 +150,5 @@ def eval_func(solver, epoch_id, log_freq):
                 tmp, (int, float)
             ), f"Target metric({type(tmp)}) should be a number"
             target_metric = tmp
-
-        visual_dir = osp.join(solver.output_dir, "visual", f"epoch_{epoch_id}")
-        if solver.rank == 0:
-            os.makedirs(visual_dir, exist_ok=True)
-            visualize.save_vtu_from_dict(
-                osp.join(visual_dir, _validator.name),
-                {**all_output, **all_input},
-                _validator.input_keys,
-                _validator.output_keys,
-                _validator.num_timestamp,
-            )
 
     return target_metric

--- a/ppsci/solver/printer.py
+++ b/ppsci/solver/printer.py
@@ -40,7 +40,7 @@ def update_eval_loss(trainer, loss_dict, batch_size):
 
 
 def log_train_info(trainer, batch_size, epoch_id, iter_id):
-    lr_msg = f"lr: {trainer.lr_scheduler.get_lr():.8f}"
+    lr_msg = f"lr: {trainer.optimizer.get_lr():.8f}"
 
     metric_msg = ", ".join(
         [
@@ -58,19 +58,18 @@ def log_train_info(trainer, batch_size, epoch_id, iter_id):
     )
 
     eta_sec = (
-        (trainer.cfg["Global"]["epochs"] - epoch_id + 1) * trainer.iters_per_epoch
-        - iter_id
+        (trainer.epochs - epoch_id + 1) * trainer.iters_per_epoch - iter_id
     ) * trainer.train_time_info["batch_cost"].avg
     eta_msg = f"eta: {str(datetime.timedelta(seconds=int(eta_sec))):s}"
     logger.info(
-        f"[Train][Epoch {epoch_id}/{trainer.cfg['Global']['epochs']}]"
+        f"[Train][Epoch {epoch_id}/{trainer.epochs}]"
         f"[Iter: {iter_id}/{trainer.iters_per_epoch}] {lr_msg}, "
         f"{metric_msg}, {time_msg}, {ips_msg}, {eta_msg}"
     )
 
     logger.scaler(
         name="lr",
-        value=trainer.lr_scheduler.get_lr(),
+        value=trainer.optimizer.get_lr(),
         step=trainer.global_step,
         writer=trainer.vdl_writer,
     )

--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -56,7 +56,7 @@ class Solver(object):
         epochs: Optional[int] = 5,
         iters_per_epoch: Optional[int] = 20,
         update_freq: Optional[int] = 1,
-        save_freq: Optional[int] = None,
+        save_freq: int = 0,
         log_freq: int = 10,
         eval_during_train: bool = False,
         start_eval_epoch: Optional[int] = 1,
@@ -277,6 +277,7 @@ class Solver(object):
             logger.info(f"[Train][Epoch {epoch_id}/{self.epochs}][Avg] {metric_msg}")
             self.train_output_info.clear()
 
+            cur_metric = float("inf")
             # evaluate during training
             if (
                 self.eval_during_train
@@ -302,7 +303,7 @@ class Solver(object):
                 logger.scaler("eval_metric", cur_metric, epoch_id, self.vdl_writer)
 
             # update learning rate by epoch
-            if self.lr_scheduler.by_epoch:
+            if self.lr_scheduler is not None and self.lr_scheduler.by_epoch:
                 self.lr_scheduler.step()
 
             # save epoch model every save_freq epochs

--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -165,6 +165,10 @@ class Solver(object):
             else:
                 self.train_epoch_func = ppsci.solver.train.train_LBFGS_epoch_func
 
+        # decorate model(s) and optimizer(s) for AMP
+        if self.use_amp:
+            self.model = amp.decorate(self.model, self.optimizer, self.amp_level)
+
         # wrap model and optimizer to parallel object
         self.rank = dist.get_rank()
         self.world_size = dist.get_world_size()

--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -66,7 +66,8 @@ class Solver(object):
         device: Literal["cpu", "gpu", "xpu"] = "gpu",
         equation: Optional[Dict[str, ppsci.equation.PDE]] = None,
         geom: Optional[Dict[str, ppsci.geometry.Geometry]] = None,
-        validator: Optional[Dict[str, Any]] = None,
+        validator: Optional[Dict[str, ppsci.validate.Validator]] = None,
+        visualizer: Optional[Dict[str, ppsci.visualize.Visualizer]] = None,
         use_amp: bool = False,
         amp_level: str = "O0",
         pretrained_model_path: Optional[str] = None,
@@ -136,6 +137,9 @@ class Solver(object):
         # set validator
         self.validator = validator
 
+        # set visualizer
+        self.visualizer = visualizer
+
         # set automatic mixed precision(AMP) configuration
         self.use_amp = use_amp
         self.amp_level = amp_level
@@ -178,6 +182,8 @@ class Solver(object):
             self.model = fleet.distributed_model(self.model)
             if self.optimizer is not None:
                 self.optimizer = fleet.distributed_optimizer(self.optimizer)
+
+        self.global_step = 0
 
         # log paddlepaddle's version
         paddle_version = (
@@ -227,7 +233,12 @@ class Solver(object):
         device = cfg["Global"].get("device", "gpu")
         validator = (
             ppsci.validate.build_validator(cfg.get("Validator", None), equation, geom)
-            if eval_during_train
+            if eval_during_train or mode == "eval"
+            else None
+        )
+        visualizer = (
+            ppsci.visualize.build_visualizer(cfg.get("Visualizer", None))
+            if eval_during_train or mode == "eval"
             else None
         )
         use_amp = "AMP" in cfg
@@ -260,6 +271,7 @@ class Solver(object):
             equation,
             geom,
             validator,
+            visualizer,
             use_amp,
             amp_level,
             pretrained_model_path,
@@ -306,6 +318,9 @@ class Solver(object):
                 )
                 logger.scaler("eval_metric", cur_metric, epoch_id, self.vdl_writer)
 
+                if self.visualizer is not None:
+                    self.visualize(epoch_id)
+
             # update learning rate by epoch
             if self.lr_scheduler is not None and self.lr_scheduler.by_epoch:
                 self.lr_scheduler.step()
@@ -339,7 +354,7 @@ class Solver(object):
         """Evaluation"""
         self.model.eval()
 
-        # init train func
+        # set eval func
         self.eval_func = ppsci.solver.eval.eval_func
 
         result = self.eval_func(self, epoch_id, self.log_freq)
@@ -351,6 +366,18 @@ class Solver(object):
 
         self.model.train()
         return result
+
+    def visualize(self, epoch_id=0):
+        """Visualization"""
+        self.model.eval()
+
+        # init train func
+        self.visu_func = ppsci.solver.visu.visualize_func
+
+        self.visu_func(self, epoch_id)
+        logger.info(f"[Visualize][Epoch {epoch_id}] Finished visualization.")
+
+        self.model.train()
 
     def predict(self, input_dict):
         """Prediction"""

--- a/ppsci/solver/train.py
+++ b/ppsci/solver/train.py
@@ -45,7 +45,7 @@ def train_epoch_func(solver, epoch_id, log_freq):
             input_dict, label_dict, weight_dict = next(_constraint.data_iter)
 
             # profile code below
-            profiler.add_profiler_step(solver.cfg["profiler_options"])
+            # profiler.add_profiler_step(solver.cfg["profiler_options"])
             if iter_id == 5:
                 # 5 step for warmup
                 for key in solver.train_time_info:
@@ -89,14 +89,14 @@ def train_epoch_func(solver, epoch_id, log_freq):
             if iter_id % solver.update_freq == 0:
                 solver.scaler.minimize(solver.optimizer, total_loss_scaled)
                 solver.optimizer.clear_grad()
-                if not solver.lr_scheduler.by_epoch:
+                if solver.lr_scheduler is not None and not solver.lr_scheduler.by_epoch:
                     solver.lr_scheduler.step()
         else:
             total_loss.backward()
             if iter_id % solver.update_freq == 0:
                 solver.optimizer.step()
                 solver.optimizer.clear_grad()
-                if not solver.lr_scheduler.by_epoch:
+                if solver.lr_scheduler is not None and not solver.lr_scheduler.by_epoch:
                     solver.lr_scheduler.step()
 
         batch_cost += time.perf_counter() - batch_tic

--- a/ppsci/solver/visu.py
+++ b/ppsci/solver/visu.py
@@ -1,0 +1,82 @@
+"""Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import os.path as osp
+
+import paddle
+import paddle.amp as amp
+
+from ppsci.utils import expression
+from ppsci.utils import misc
+
+
+def visualize_func(solver, epoch_id):
+    """Visualization program
+
+    Args:
+        solver (Solver): Main Solver.
+        epoch_id (int): Epoch id.
+
+    Returns:
+        Dict[str, Any]: Metric collected during visualization.
+    """
+    for _, _visualizer in solver.visualizer.items():
+        all_input = misc.Prettydefaultdict(list)
+        all_output = misc.Prettydefaultdict(list)
+
+        input_dict = _visualizer.input_dict
+        for key in input_dict:
+            if not paddle.is_tensor(input_dict[key]):
+                input_dict[key] = paddle.to_tensor(input_dict[key], stop_gradient=False)
+
+        evaluator = expression.ExpressionSolver(
+            _visualizer.input_keys, _visualizer.output_keys, solver.model
+        )
+        for output_key, output_expr in _visualizer.output_expr.items():
+            evaluator.add_target_expr(output_expr, output_key)
+
+        # forward
+        if solver.use_amp:
+            with amp.auto_cast(level=solver.amp_level):
+                output_dict = evaluator(input_dict)
+        else:
+            output_dict = evaluator(input_dict)
+
+        # collect batch data
+        for key, input in input_dict.items():
+            all_input[key].append(
+                input.detach()
+                if solver.world_size == 1
+                else misc.all_gather(input.detach())
+            )
+        for key, output in output_dict.items():
+            all_output[key].append(
+                output.detach()
+                if solver.world_size == 1
+                else misc.all_gather(output.detach())
+            )
+
+        for key in all_input:
+            all_input[key] = paddle.concat(all_input[key])
+        for key in all_output:
+            all_output[key] = paddle.concat(all_output[key])
+
+        if solver.rank == 0:
+            visual_dir = osp.join(solver.output_dir, "visual", f"epoch_{epoch_id}")
+            os.makedirs(visual_dir, exist_ok=True)
+            _visualizer.save(
+                osp.join(visual_dir, _visualizer.prefix), {**all_input, **all_output}
+            )

--- a/ppsci/utils/misc.py
+++ b/ppsci/utils/misc.py
@@ -19,6 +19,7 @@ import random
 
 import numpy as np
 import paddle
+import paddle.distributed as dist
 
 from ppsci.utils import logger
 
@@ -33,6 +34,7 @@ __all__ = [
     "load_csv_file",
     "stack_dict_list",
     "combine_array_with_time",
+    "set_random_seed",
 ]
 
 
@@ -201,6 +203,7 @@ def load_csv_file(file_path, keys, alias_dict=None, encoding="utf-8"):
 
 
 def set_random_seed(seed):
-    paddle.seed(seed)
-    np.random.seed(seed)
-    random.seed(seed)
+    rank = dist.get_rank()
+    paddle.seed(seed + rank)
+    np.random.seed(seed + rank)
+    random.seed(seed + rank)

--- a/ppsci/visualize/__init__.py
+++ b/ppsci/visualize/__init__.py
@@ -13,7 +13,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from ppsci.visualize.vtu import save_vtu_from_array
+import copy
+
+from ppsci.visualize.visualizer import Visualizer
+from ppsci.visualize.visualizer import VisualizerScatter1D
+from ppsci.visualize.visualizer import VisualizerVtu
 from ppsci.visualize.vtu import save_vtu_from_dict
 
-__all__ = ["save_vtu_from_array", "save_vtu_from_dict"]
+__all__ = ["Visualizer", "VisualizerScatter1D", "VisualizerVtu", "save_vtu_from_dict"]
+
+
+def build_visualizer(cfg):
+    """Build visualizer(s).
+
+    Args:
+        cfg (List[AttrDict]): Visualizer(s) config list.
+        geom_dict (Dct[str, Geometry]): Geometry(ies) in dict.
+        equation_dict (Dct[str, Equation]): Equation(s) in dict.
+
+    Returns:
+        Dict[str, Visualizer]: Visualizer(s) in dict.
+    """
+    if cfg is None:
+        return None
+    cfg = copy.deepcopy(cfg)
+
+    visualizer_dict = {}
+    for _item in cfg:
+        visualizer_cls = next(iter(_item.keys()))
+        visualizer_cfg = _item[visualizer_cls]
+        visualizer = eval(visualizer_cls)(**visualizer_cfg)
+
+        visualizer_name = visualizer_cfg.get("name", visualizer_cls)
+        if visualizer_name in visualizer_dict:
+            raise ValueError(f"Name of visualizer({visualizer_name}) should be unique")
+        visualizer_dict[visualizer_name] = visualizer
+
+    return visualizer_dict

--- a/ppsci/visualize/base.py
+++ b/ppsci/visualize/base.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+
+
+class Visualizer(object):
+    def __init__(self, filename, coord_keys, values_keys, num_timestamps):
+        self.filename = filename
+        self.coord_keys = coord_keys
+        self.dim = len(coord_keys)
+        self.values_keys = values_keys
+        self.num_timestamps = num_timestamps
+
+    @abc.abstractmethod
+    def save(self, data_dict):
+        """visualize result from data_dict and save as files"""
+
+    def __str__(self):
+        return ", ".join(
+            [
+                f"filename: {self.filename}",
+                f"coord_keys: {self.coord_keys}",
+                f"dim: {self.dim}",
+                f"values_keys: {self.values_keys}",
+                f"num_timestamps: {self.num_timestamps}",
+            ]
+        )

--- a/ppsci/visualize/plot.py
+++ b/ppsci/visualize/plot.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import paddle
+from matplotlib import pyplot as plt
+
+from ppsci.utils import logger
+
+cnames = [
+    "bisque",
+    "black",
+    "blanchedalmond",
+    "blue",
+    "blueviolet",
+    "brown",
+    "burlywood",
+    "cadetblue",
+    "chartreuse",
+    "orangered",
+    "orchid",
+    "palegoldenrod",
+    "palegreen",
+]
+
+
+def _save_plot_from_1d_array(filename, coord, value, value_keys, num_timestamp=1):
+    """Save plot from given 1D data.
+
+    Args:
+        filename (str): Filename.
+        coord (np.ndarray): Coordinate array.
+        value (Dict[str, np.ndarray]): Dict of value array.
+        value_keys (List[str]): Value keys.
+        num_timestamp (int, optional): Number of timestamps coord/value contains. Defaults to 1.
+    """
+    fig, a = plt.subplots(len(value_keys), num_timestamp, squeeze=False)
+
+    len_ts = len(coord) // num_timestamp
+    for t in range(num_timestamp):
+        st = t * len_ts
+        ed = (t + 1) * len_ts
+        coord_t = coord[st:ed]
+        sorted_index = np.argsort(coord, axis=0).squeeze()
+
+        for i, key in enumerate(value_keys):
+            _value_t: np.ndarray = value[st:ed, i]
+            a[i][t].plot(
+                coord_t,
+                _value_t[sorted_index],
+                color=cnames[i],
+                label=key,
+            )
+            a[i][t].set_title(f"{key}(t={t})")
+            a[i][t].grid()
+            a[i][t].legend()
+
+        if num_timestamp == 1:
+            fig.savefig(filename, dpi=300)
+        else:
+            fig.savefig(f"{filename}_{t}", dpi=300)
+
+    if num_timestamp == 1:
+        logger.info(f"1D result is saved to {filename}.png")
+    else:
+        logger.info(
+            f"1D result is saved to {filename}_0.png"
+            f" ~ {filename}_{num_timestamp - 1}.png"
+        )
+
+
+def save_plot_from_1d_dict(
+    filename, data_dict, coord_keys, value_keys, num_timestamp=1
+):
+    """Plot dict data as file.
+
+    Args:
+        filename (str): Output filename.
+        data_dict (Dict[str, Union[np.ndarray, paddle.Tensor]]): Data in dict.
+        coord_keys (List[str]): List of coord key. such as ["x", "y"].
+        value_keys (List[str]): List of value key. such as ["u", "v"].
+        num_timestamp (int, optional): Number of timestamp in data_dict. Defaults to 1.
+    """
+    space_ndim = len(coord_keys) - int("t" in coord_keys)
+    if space_ndim not in [1, 2, 3]:
+        raise ValueError(f"ndim of space coord ({space_ndim}) should be 1, 2 or 3")
+
+    coord = [data_dict[k] for k in coord_keys if k != "t"]
+    value = [data_dict[k] for k in value_keys] if value_keys else None
+
+    if isinstance(coord[0], paddle.Tensor):
+        coord = [x.numpy() for x in coord]
+    else:
+        coord = [x for x in coord]
+    coord = np.concatenate(coord, axis=1)
+
+    if value is not None:
+        if isinstance(value[0], paddle.Tensor):
+            value = [x.numpy() for x in value]
+        else:
+            value = [x for x in value]
+        value = np.concatenate(value, axis=1)
+
+    _save_plot_from_1d_array(filename, coord, value, value_keys, num_timestamp)

--- a/ppsci/visualize/visualizer.py
+++ b/ppsci/visualize/visualizer.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+
+from ppsci.visualize import plot
+from ppsci.visualize import vtu
+
+
+class Visualizer(object):
+    def __init__(self, input_dict, output_expr, num_timestamps, prefix):
+        self.input_dict = input_dict
+        self.input_keys = list(input_dict.keys())
+        self.dim = len(self.input_keys)
+        self.output_expr = output_expr
+        self.output_keys = list(output_expr.keys())
+        self.num_timestamps = num_timestamps
+        self.prefix = prefix
+
+    @abc.abstractmethod
+    def save(self, data_dict):
+        """visualize result from data_dict and save as files"""
+
+    def __str__(self):
+        return ", ".join(
+            [
+                f"input_keys: {self.input_keys}",
+                f"dim: {self.dim}",
+                f"output_keys: {self.output_keys}",
+                f"output_expr: {self.output_expr}",
+                f"num_timestamps: {self.num_timestamps}",
+            ]
+        )
+
+
+class VisualizerScatter1D(Visualizer):
+    def __call__(self, input_dict, output_expr, num_timestamps=1, prefix="plot"):
+        super().__init__(input_dict, output_expr, num_timestamps, prefix)
+
+    def save(self, data_dict, filename):
+        plot.save_plot_from_1d_dict(
+            filename, data_dict, self.input_keys, self.output_keys, self.num_timestamps
+        )
+
+
+class VisualizerVtu(Visualizer):
+    def __call__(self, input_dict, output_expr, num_timestamps=1, prefix="vtu"):
+        super().__init__(input_dict, output_expr, num_timestamps, prefix)
+
+    def save(self, filename, data_dict):
+        vtu.save_vtu_from_dict(
+            filename, data_dict, self.input_keys, self.output_keys, self.num_timestamps
+        )
+
+
+class Visualizer3D(Visualizer):
+    def __call__(self, input_dict, output_expr, num_timestamps=1, prefix="plot3d"):
+        super().__init__(input_dict, output_expr, num_timestamps, prefix)
+
+    def save(self, filename, data_dict):
+        vtu.save_vtu_from_dict(
+            filename, data_dict, self.input_keys, self.output_keys, self.num_timestamps
+        )

--- a/ppsci/visualize/vtu.py
+++ b/ppsci/visualize/vtu.py
@@ -20,7 +20,7 @@ from pyevtk import hl
 from ppsci.utils import logger
 
 
-def save_vtu_from_array(filename, coord, value, value_keys, num_timestamp=1):
+def _save_vtu_from_array(filename, coord, value, value_keys, num_timestamp=1):
     """Save data to '*.vtu' file(s).
 
     Args:
@@ -83,7 +83,7 @@ def save_vtu_from_array(filename, coord, value, value_keys, num_timestamp=1):
 
     if num_timestamp > 1:
         logger.info(
-            f"Visualization results are saved to {filename}_t-1 ~ {filename}_t-{num_timestamp}"
+            f"Visualization results are saved to {filename}_t-0 ~ {filename}_t-{num_timestamp - 1}"
         )
     else:
         logger.info(f"Visualization result is saved to {filename}")
@@ -97,7 +97,6 @@ def save_vtu_from_dict(filename, data_dict, coord_keys, value_keys, num_timestam
         data_dict (Dict[str, Union[np.ndarray, paddle.Tensor]]): Data in dict.
         coord_keys (List[str]): List of coord key. such as ["x", "y"].
         value_keys (List[str]): List of value key. such as ["u", "v"].
-        ndim (int): Number of coord dimension in data_dict.
         num_timestamp (int, optional): Number of timestamp in data_dict. Defaults to 1.
     """
     if len(coord_keys) not in [2, 3, 4]:
@@ -119,4 +118,4 @@ def save_vtu_from_dict(filename, data_dict, coord_keys, value_keys, num_timestam
             value = [x for x in value]
         value = np.concatenate(value, axis=1)
 
-    save_vtu_from_array(filename, coord, value, value_keys, num_timestamp)
+    _save_vtu_from_array(filename, coord, value, value_keys, num_timestamp)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
New features

### PR changes
APIs 

### Describe
主要修改点：
1. 添加ldc2d_unsteady(Re=10)

其他：
1. 修复 `TimeDomain` 在给定 `criteria` 时，将 criteria 筛选步骤放置在空间-时间采样之后的BUG，预期逻辑应该是先进行空间采样，然后用criteria对空间采样点进行过滤，然后再进行时间采样，最后生成空间-时间数据，而目前的逻辑是空间采样->时间采样->criteria，这会导致实际生成的数据中，每个时间戳对应的一段数据的t并不都一致（如时刻t0对应的数据data_t0=[N, 3]， 其中data_t0[:, 0]的元素并不都等于t0)
2. 添加 `Visualizer` 基类，以及根据保存数据的结构不同，派生的几个类，以此从 eval 中将可视化过程分离为单独的`Solver.visualize` 方法
3. 按照import依赖先后关系，调整 `ppsci/__init__.py` 中import的顺序，避免找不到包的问题
