### PR TITLE
fix cylinder2d doc and InfiniteDataLoader

### DIFF
--- a/docs/zh/examples/cylinder2d_unsteady.md
+++ b/docs/zh/examples/cylinder2d_unsteady.md
@@ -104,7 +104,7 @@ $$
 
 ``` py linenums="28"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:28:31
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:28:31
 --8<--
 ```
 
@@ -118,7 +118,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:28:31
 
 ``` py linenums="32"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:32:33
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:32:33
 --8<--
 ```
 
@@ -232,7 +232,7 @@ geom = {
 
 ``` py linenums="75"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:75:87
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:75:87
 --8<--
 ```
 
@@ -242,7 +242,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:75:87
 
 ``` py linenums="89"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:89:97
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:89:97
 --8<--
 ```
 
@@ -282,7 +282,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:89:97
 
 ``` py linenums="98"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:98:118
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:98:118
 --8<--
 ```
 
@@ -292,7 +292,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:98:118
 
 ``` py linenums="122"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:122:132
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:122:132
 --8<--
 ```
 
@@ -302,7 +302,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:122:132
 
 ``` py linenums="133"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:133:143
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:133:143
 --8<--
 ```
 
@@ -310,7 +310,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:133:143
 
 ``` py linenums="144"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:144:151
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:144:151
 --8<--
 ```
 
@@ -320,7 +320,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:144:151
 
 ``` py linenums="153"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:153:155
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:153:155
 --8<--
 ```
 
@@ -330,7 +330,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:153:155
 
 ``` py linenums="157"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:157:158
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:157:158
 --8<--
 ```
 
@@ -340,7 +340,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:157:158
 
 ``` py linenums="160"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:160:176
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:160:176
 --8<--
 ```
 
@@ -364,7 +364,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:160:176
 
 ``` py linenums="178"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:178:189
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:178:189
 --8<--
 ```
 
@@ -374,7 +374,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:178:189
 
 ``` py linenums="191"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:191:
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py:191:
 --8<--
 ```
 
@@ -382,7 +382,7 @@ examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py:191:
 
 ``` py linenums="1" title="cylinder2d_unsteady_Re100.py"
 --8<--
-examples/cylinder/2d_unsteady_continuous/cylinder2d_unsteady_Re100.py
+examples/cylinder/2d_unsteady/cylinder2d_unsteady_Re100.py
 --8<--
 ```
 

--- a/ppsci/arch/__init__.py
+++ b/ppsci/arch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) xxx Authors. All Rights Reserved.
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ppsci/data/dataloader.py
+++ b/ppsci/data/dataloader.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union
+
 from paddle import io
 
 
@@ -19,12 +21,19 @@ class InfiniteDataLoader(object):
     """A wrapper for infinite dataloader.
 
     Args:
-        dataloader (DataLoader): A finite and iterable loader to be wrapped.
+        dataloader (Union[io.DataLoader, io.IterableDataset]): A finite and iterable loader or iterable dataset to be wrapped.
     """
 
-    def __init__(self, dataloader: io.DataLoader):
+    def __init__(self, dataloader: Union[io.DataLoader, io.IterableDataset]):
         self.dataloader = dataloader
-        self.dataset = dataloader.dataset
+        if isinstance(dataloader, io.DataLoader):
+            self.dataset = dataloader.dataset
+        elif isinstance(dataloader, io.IterableDataset):
+            self.dataset = dataloader
+        else:
+            raise TypeError(
+                f"dataloader should be io.DataLoader or io.IterableDataset, but got {type(dataloader)}"
+            )
 
     def __iter__(self):
         while True:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->
1. 修复cylinder 2d文档中引用的路径问题；
2. 修复InfiniteDataLoader传入IterableDataset类型时的报错