### PR TITLE
fit current running steps into standard

### DIFF
--- a/test_tipc/README.MD
+++ b/test_tipc/README.MD
@@ -42,10 +42,9 @@ cd ..
 ```
 在PaddleScience主目录下运行
 ```
-export prepare_params=./test_tipc/configs/train_2d_unsteady_continuous/prepare_2d_unsteady_continuous.txt 
-export train_params=./test_tipc/configs/train_2d_unsteady_continuous/train_2d_unsteady_continuous.txt
-source ./test_tipc/prepare.sh $prepare_params benchmark_train
-bash ./test_tipc/benchmark_train.sh  $train_params benchmark_train
+export script_path=./test_tipc/configs/train_2d_unsteady_continuous/train_2d_unsteady_continuous.txt
+bash ./test_tipc/prepare.sh $script_path benchmark_train
+bash ./test_tipc/benchmark_train.sh  $script_path benchmark_train
 ```
 benchmark训练得到训练日志后，会自动保存训练日志并解析得到ips等信息，日志解析代码位于：
 - https://console.cloud.baidu-int.com/devops/icode/repos/baidu/paddle/benchmark-frame/blob/master/tools/scripts/analysis.py

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -201,9 +201,6 @@ for batch_size in ${batch_size_list[*]}; do
                 eval "cat ${log_path}/${log_name}"
                 # parser log
                 _model_name="${model_name}_bs${batch_size}_${precision}_${run_mode}"
-
-                echo -e "\n* [BENCHMARK_ROOT] is now set : \n" ${BENCHMARK_ROOT} "\n"
-
                 cmd="${python} ${BENCHMARK_ROOT}/scripts/analysis.py --filename ${log_path}/${log_name} \
                         --speed_log_file '${speed_log_path}/${speed_log_name}' \
                         --model_name ${_model_name} \

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -13,6 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+export PDSC_DIR=$(cd "$( dirname ${BASH_SOURCE[0]})"; cd ..; pwd)
+export TEST_DIR="${PDSC_DIR}"
+export TIPC_TEST="ON" # open tipc log in solver.py 
+export PYTHONPATH=${PDSC_DIR}
+BENCHMARK_ROOT=${TEST_DIR}"/test_tipc/tools"
 source ${TEST_DIR}/test_tipc/common_func.sh
 
 function func_parser_params(){
@@ -86,7 +91,7 @@ line_num=`expr $line_num + 1`
 fp_items=$(func_parser_value "${lines[line_num]}")
 line_num=`expr $line_num + 1`
 epoch=$(func_parser_value "${lines[line_num]}")
-
+pip=$(func_parser_value "${lines[59]}")
 line_num=`expr $line_num + 1`
 profile_option_key=$(func_parser_key "${lines[line_num]}")
 profile_option_params=$(func_parser_value "${lines[line_num]}")
@@ -197,6 +202,9 @@ for batch_size in ${batch_size_list[*]}; do
                 eval "cat ${log_path}/${log_name}"
                 # parser log
                 _model_name="${model_name}_bs${batch_size}_${precision}_${run_mode}"
+
+                echo -e "\n* [BENCHMARK_ROOT] is now set : \n" ${BENCHMARK_ROOT} "\n"
+
                 cmd="${python} ${BENCHMARK_ROOT}/scripts/analysis.py --filename ${log_path}/${log_name} \
                         --speed_log_file '${speed_log_path}/${speed_log_name}' \
                         --model_name ${_model_name} \

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -17,7 +17,6 @@ export PDSC_DIR=$(cd "$( dirname ${BASH_SOURCE[0]})"; cd ..; pwd)
 export TEST_DIR="${PDSC_DIR}"
 export TIPC_TEST="ON" # open tipc log in solver.py 
 export PYTHONPATH=${PDSC_DIR}
-BENCHMARK_ROOT=${TEST_DIR}"/test_tipc/tools"
 source ${TEST_DIR}/test_tipc/common_func.sh
 
 function func_parser_params(){

--- a/test_tipc/configs/train_2d_unsteady_continuous/prepare_2d_unsteady_continuous.txt
+++ b/test_tipc/configs/train_2d_unsteady_continuous/prepare_2d_unsteady_continuous.txt
@@ -1,4 +1,0 @@
-===========================prepare_params===========================
-download_dataset:/examples/cylinder/2d_unsteady/download_dataset.py
-python:python3.7
-pip:pip

--- a/test_tipc/configs/train_2d_unsteady_continuous/train_2d_unsteady_continuous.txt
+++ b/test_tipc/configs/train_2d_unsteady_continuous/train_2d_unsteady_continuous.txt
@@ -55,3 +55,6 @@ fp_items:fp32
 epoch:20
 --profiler_options:batch_range=[1,1];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=0
+===========================prepare_params==========================
+download_dataset:/examples/cylinder/2d_unsteady/download_dataset.py
+pip:pip

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -19,7 +19,5 @@ download_dataset=$(func_parser_value "${lines[61]}")
 python=$(func_parser_value "${lines[2]}")
 export pip=$(func_parser_value "${lines[62]}")
 
-echo -e "\n* [download_dataset] is now set : \n" ${download_dataset} "\n"
-
 ${pip} install -r requirements.txt
 ${python} ${PDSC_DIR}${download_dataset}

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -15,9 +15,11 @@ source ${TEST_DIR}/test_tipc/common_func.sh
 PREPARE_PARAM_FILE=$1
 dataline=`cat $PREPARE_PARAM_FILE`
 lines=(${dataline})
-download_dataset=$(func_parser_value "${lines[1]}")
+download_dataset=$(func_parser_value "${lines[61]}")
 python=$(func_parser_value "${lines[2]}")
-export pip=$(func_parser_value "${lines[3]}")
+export pip=$(func_parser_value "${lines[62]}")
+
+echo -e "\n* [download_dataset] is now set : \n" ${download_dataset} "\n"
 
 ${pip} install -r requirements.txt
 ${python} ${PDSC_DIR}${download_dataset}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
1. fix README.MD to the standard process of running the script
2. export environment variables in train.sh because strict bash format
### Describe
ensure the way of running benchmarks like:
```
export script_path=xxx
bash ./test_tipc/prepare.sh $script_path benchmark_train
bash ./test_tipc/benchmark_train.sh  $script_path benchmark_train
```