### PR TITLE
add ModelList for multiple models case

### DIFF
--- a/docs/zh/api/arch.md
+++ b/docs/zh/api/arch.md
@@ -9,5 +9,6 @@
         - RosslerEmbedding
         - CylinderEmbedding
         - PhysformerGPT2
+        - ModelList
       show_root_heading: false
       heading_level: 3

--- a/ppsci/arch/__init__.py
+++ b/ppsci/arch/__init__.py
@@ -19,6 +19,7 @@ from ppsci.arch.embedding_koopman import LorenzEmbedding  # isort:skip
 from ppsci.arch.embedding_koopman import RosslerEmbedding  # isort:skip
 from ppsci.arch.embedding_koopman import CylinderEmbedding  # isort:skip
 from ppsci.arch.physx_transformer import PhysformerGPT2  # isort:skip
+from ppsci.arch.model_list import ModelList  # isort:skip
 from ppsci.utils import logger  # isort:skip
 
 
@@ -28,6 +29,7 @@ __all__ = [
     "RosslerEmbedding",
     "CylinderEmbedding",
     "PhysformerGPT2",
+    "ModelList",
     "build_model",
 ]
 

--- a/ppsci/arch/model_list.py
+++ b/ppsci/arch/model_list.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple
+
+from ppsci.arch import base
+
+
+class ModelList(base.NetBase):
+    """ModelList layer which wrap more than one model that shares inputs.
+
+    Args:
+        model_list (Tuple[base.NetBase, ...]): Model(s) nesteed in tuple.
+    """
+
+    def __init__(
+        self,
+        model_list: Tuple[base.NetBase, ...],
+    ):
+        super().__init__()
+        output_keys_set = set()
+        for model in model_list:
+            if len(output_keys_set & set(model.output_keys)):
+                raise ValueError(
+                    "output_keys of model from model_list should be unique,"
+                    f"but got duplicate keys: {output_keys_set & set(model.output_keys)}"
+                )
+            output_keys_set = output_keys_set | set(model.output_keys)
+
+        self.model_list = model_list
+
+    def forward(self, x):
+        y_all = {}
+        for model in self.model_list:
+            if model._input_transform is not None:
+                x = model._input_transform(x)
+
+            y = model.concat_to_tensor(x, model.input_keys, axis=-1)
+            y = model.forward_tensor(y)
+            y = model.split_to_dict(y, model.output_keys, axis=-1)
+
+            if model._output_transform is not None:
+                y = model._output_transform(y)
+            y_all.update(y)
+
+        return y_all


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
New features

### PR changes
APIs

### Describe
主要修改点：
针对多模型场景，添加 `Class ModelList` 用以将多个在训练时共享输入（或共享一部分输入）的模型包装为一个集成的模型
