### PR TITLE
Improve default_collate_fn to allow None field in data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,3 @@ FETCH_HEAD
 # vtk
 *.vtk
 *.vtu
-
-# mkdocs
-site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,10 +42,9 @@ nav:
       - ppsci.autodiff: zh/api/autodiff.md
       - ppsci.constraint: zh/api/constraint.md
       - ppsci.data:
-          - dataset: zh/api/data/dataset.md
-          - process:
-            - transform: zh/api/data/process/transform.md
-            - batch_transform: zh/api/data/process/batch_transform.md
+          - ppsci.data.dataset: zh/api/data/dataset.md
+          - ppsci.data.transform: zh/api/data/process/transform.md
+          - ppsci.data.batch_transform: zh/api/data/process/batch_transform.md
       - ppsci.equation: zh/api/equation.md
       - ppsci.geometry: zh/api/geometry.md
       - ppsci.loss: zh/api/loss.md

--- a/ppsci/arch/model_list.py
+++ b/ppsci/arch/model_list.py
@@ -14,6 +14,8 @@
 
 from typing import Tuple
 
+from paddle import nn
+
 from ppsci.arch import base
 
 
@@ -38,7 +40,7 @@ class ModelList(base.NetBase):
                 )
             output_keys_set = output_keys_set | set(model.output_keys)
 
-        self.model_list = model_list
+        self.model_list = nn.LayerList(model_list)
 
     def forward(self, x):
         y_all = {}

--- a/ppsci/data/__init__.py
+++ b/ppsci/data/__init__.py
@@ -32,9 +32,17 @@ from ppsci.data import dataloader
 from ppsci.data import dataset
 from ppsci.data import process
 from ppsci.data.process import batch_transform
+from ppsci.data.process import transform
 from ppsci.utils import logger
 
-__all__ = ["dataset", "process", "dataloader", "build_dataloader"]
+__all__ = [
+    "dataset",
+    "process",
+    "dataloader",
+    "build_dataloader",
+    "transform",
+    "batch_transform",
+]
 
 
 def _default_collate_fn_allow_none(batch: List[Any]) -> Any:
@@ -143,7 +151,6 @@ def build_dataloader(_dataset, cfg):
     dataloader = io.DataLoader(
         dataset=_dataset,
         places=device.get_device(),
-        return_list=True,
         batch_sampler=sampler,
         collate_fn=collate_fn,
         num_workers=cfg.get("num_workers", 0),

--- a/ppsci/data/process/transform/__init__.py
+++ b/ppsci/data/process/transform/__init__.py
@@ -25,7 +25,7 @@ __all__ = ["Scale", "Translate", "build_transforms"]
 
 def build_transforms(cfg):
     if not cfg:
-        return None
+        return vision.Compose([])
     cfg = copy.deepcopy(cfg)
 
     transform_list = []

--- a/ppsci/solver/eval.py
+++ b/ppsci/solver/eval.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import time
-from typing import Any
-from typing import Dict
 
 import paddle
 import paddle.amp as amp
@@ -26,7 +24,7 @@ from ppsci.utils import misc
 from ppsci.utils import profiler
 
 
-def eval_func(solver, epoch_id, log_freq) -> Dict[str, Any]:
+def eval_func(solver, epoch_id, log_freq) -> float:
     """Evaluation program
 
     Args:
@@ -35,9 +33,9 @@ def eval_func(solver, epoch_id, log_freq) -> Dict[str, Any]:
         log_freq (int): Log evaluation information every `log_freq` steps.
 
     Returns:
-        Dict[str, Any]: Metric collected during evaluation.
+        float: Target metric computed during evaluation.
     """
-    target_metric = None
+    target_metric: float = None
     for _, _validator in solver.validator.items():
         all_input = misc.Prettydefaultdict(list)
         all_output = misc.Prettydefaultdict(list)


### PR DESCRIPTION
改进 `default_collate_fn` 以支持加载含 `None` 的数据
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
Function optimization

### PR changes
APIs

### Describe
主要修改点：
1. 参考 Paddle 已有的 `default_collate_fn`，修改得到 `_default_collate_fn_allow_none`，以支持某一字段为None的情况，该函数允许样本中含有 `None` 字段，此时组完 batch 后返回的也是 `None`。
2. 优化 `collate_fn_batch_transforms` 代码，复用 `_default_collate_fn_allow_none` 函数，减少冗余代码

其他：
1. 令 `transform` 和 `batch_transform` 模块在 `ppsci.data` 下可见，同时修改了其在 API 文档中的路径
2. 在 `ModelList` 中对传入的模型列表包裹一层 `nn.LayerList` 以让模型列表的属性能被正常注册到 Layer 中
3. 修正了 `eval_func` 返回值的type hint