### PR TITLE
reshape norm output to 0-D tensor manually

### DIFF
--- a/paddlescience/network/grad_norm.py
+++ b/paddlescience/network/grad_norm.py
@@ -84,8 +84,8 @@ class GradNorm(NetworkBase):
         norms = []
         for i in range(losses.shape[0]):
             grad = paddle.autograd.grad(losses[i], W, retain_graph=True)
-            norms.append(paddle.norm(self.loss_weights[i] * grad[0], p=2))
-        norms = paddle.concat(norms)
+            norms.append(paddle.norm(self.loss_weights[i] * grad[0], p=2).reshape([]))
+        norms = paddle.stack(norms)
 
         # calculate the inverse train rate
         loss_ratio = losses.numpy() / self.initial_losses


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 适配框架 paddle.norm 输出形状变为0-Dtensor的改动，因此手动将 `paddlescience/network/grad_norm.py` 中涉及到norm的输出reshape成[]（兼容老版本paddle）