### PR TITLE
control no_grad for visualize_func

### DIFF
--- a/ppsci/solver/visu.py
+++ b/ppsci/solver/visu.py
@@ -59,7 +59,7 @@ def visualize_func(solver, epoch_id: int):
                 evaluator.add_target_expr(output_expr, output_key)
 
             # forward
-            with solver.autocast_context_manager():
+            with solver.autocast_context_manager(), solver.no_grad_context_manager():
                 batch_output_dict = evaluator(batch_input_dict)
 
             # collect batch data

--- a/ppsci/solver/visu.py
+++ b/ppsci/solver/visu.py
@@ -21,7 +21,6 @@ from ppsci.utils import expression
 from ppsci.utils import misc
 
 
-@paddle.no_grad()
 def visualize_func(solver, epoch_id: int):
     """Visualization program
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 个别案例如 VIV 需要可视化具有物理意义的高阶微分变量，故使用 `eval_with_no_grad` 控制可视化函数上的中是否开启梯度功能