### PR TITLE
add 'area' from input_dict into output_dict

### DIFF
--- a/ppsci/utils/expression.py
+++ b/ppsci/utils/expression.py
@@ -65,6 +65,10 @@ class ExpressionSolver(nn.Layer):
                 else:
                     raise TypeError(f"expr type({type(expr)}) is invalid")
 
+            # put field 'area' into output_dict
+            if "area" in input_dicts[i]:
+                output_dict["area"] = input_dicts[i]["area"]
+
             output_dicts.append(output_dict)
 
             # clear differentiation cache


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 在 `output_dict` 中添加来自 `input_dict` 的 `area` 字段供损失函数计算加权使用