### PR TITLE
support multi-gpu prediction

### DIFF
--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -20,6 +20,7 @@ import itertools
 import os
 import sys
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Union
@@ -261,7 +262,7 @@ class Solver:
             logger.warning(
                 f"Detected world_size({self.world_size}) > 1, it is recommended to "
                 "scale up the learning rate and reduce the epochs or "
-                "iters_per_epoch according to the world_size number both linearly."
+                "iters_per_epoch according to the world_size both linearly."
             )
 
         self.global_step = 0
@@ -468,55 +469,100 @@ class Solver:
         self.visu_func(self, epoch_id)
         logger.info(f"[Visualize][Epoch {epoch_id}] Finished visualization")
 
-    @paddle.no_grad()
     @misc.run_on_eval_mode
     def predict(
         self,
         input_dict: Dict[str, Union[np.ndarray, paddle.Tensor]],
+        expr_dict: Optional[Dict[str, Callable]] = None,
         batch_size: int = 64,
+        no_grad: bool = True,
     ) -> Dict[str, paddle.Tensor]:
-        """Pure prediction using model.forward(...), support single device prediction yet.
+        """Pure prediction using model.forward(...) and expression(optional, if given).
 
         Args:
             input_dict (Dict[str, Union[np.ndarray, paddle.Tensor]]): Input data in dict.
+            expr_dict (Optional[Dict[str, Callable]]): Expression dict, which guide to
+                compute equation variable with callable function. Defaults to None.
             batch_size (int, optional): Predicting by batch size. Defaults to 64.
-
+            no_grad (bool): Whether set stop_gradient=True for entire prediction, mainly
+                for memory-efficiency. Defaults to True.
         Returns:
             Dict[str, paddle.Tensor]: Prediction in dict.
         """
-        if self.world_size > 1:
-            raise NotImplementedError(
-                "Solver.predict only support single device yet, "
-                f"but got {self.world_size} devices."
-            )
-
         num_samples = len(next(iter(input_dict.values())))
-        batch_num = (num_samples + (batch_size - 1)) // batch_size
+        num_pad = (self.world_size - num_samples % self.world_size) % self.world_size
+        # pad with last element if `num_samples` is not divisible by `world_size`
+        # ensuring every device get same number of data.
+        if num_pad > 0:
+            for k, v in input_dict.items():
+                repeat_times = (num_pad, *(1 for _ in range(v.ndim - 1)))
+                input_dict[k] = paddle.concat(
+                    (
+                        v,
+                        paddle.tile(v[num_samples - 1 : num_samples], repeat_times),
+                    ),
+                )
+
+        num_samples_pad = num_samples + num_pad
+        local_num_samples_pad = num_samples_pad // self.world_size
+        local_input_dict = (
+            {k: v[self.rank :: self.world_size] for k, v in input_dict.items()}
+            if self.world_size > 1
+            else input_dict
+        )
+        local_batch_num = (local_num_samples_pad + (batch_size - 1)) // batch_size
         pred_dict = misc.Prettydefaultdict(list)
-        for batch_id in range(batch_num):
-            batch_input_dict = {}
-            st = batch_id * batch_size
-            ed = min(num_samples, (batch_id + 1) * batch_size)
+        with self.no_grad_context_manager(no_grad), self.no_sync_context_manager(
+            self.world_size > 1, self.model
+        ):
+            for batch_id in range(local_batch_num):
+                batch_input_dict = {}
+                st = batch_id * batch_size
+                ed = min(local_num_samples_pad, (batch_id + 1) * batch_size)
 
-            # prepare batch input dict
-            for key in input_dict:
-                if not paddle.is_tensor(input_dict[key]):
-                    batch_input_dict[key] = paddle.to_tensor(
-                        input_dict[key][st:ed], paddle.get_default_dtype()
+                # prepare batch input dict
+                for key in local_input_dict:
+                    if not paddle.is_tensor(local_input_dict[key]):
+                        batch_input_dict[key] = paddle.to_tensor(
+                            local_input_dict[key][st:ed], paddle.get_default_dtype()
+                        )
+                    else:
+                        batch_input_dict[key] = local_input_dict[key][st:ed]
+                    batch_input_dict[key].stop_gradient = no_grad
+
+                # forward
+                with self.autocast_context_manager(self.use_amp, self.amp_level):
+                    batch_output_dict = self.forward_helper.visu_forward(
+                        expr_dict, batch_input_dict, self.model
                     )
-                else:
-                    batch_input_dict[key] = input_dict[key][st:ed]
-                batch_input_dict[key].stop_gradient = False
 
-            # forward
-            with self.autocast_context_manager(self.use_amp, self.amp_level):
-                batch_output_dict = self.model(batch_input_dict)
+                # collect batch data
+                for key, batch_output in batch_output_dict.items():
+                    pred_dict[key].append(batch_output.detach())
 
-            # collect batch data
-            for key, batch_output in batch_output_dict.items():
-                pred_dict[key].append(batch_output)
+            # concatenate local predictions
+            pred_dict = {key: paddle.concat(value) for key, value in pred_dict.items()}
 
-        pred_dict = {key: paddle.concat(value) for key, value in pred_dict.items()}
+            if self.world_size > 1:
+                # gather global predictions from all devices if world_size > 1
+                pred_dict = {
+                    key: misc.all_gather(value) for key, value in pred_dict.items()
+                }
+
+                # rearange predictions as the same order of input_dict according to inverse
+                # permutation, then discard predictions of padding data at the end
+                perm = np.arange(num_samples_pad, dtype="int64")
+                perm = np.concatenate(
+                    [perm[rank :: self.world_size] for rank in range(self.world_size)],
+                    axis=0,
+                )
+                perm_inv = np.empty_like(perm)
+                perm_inv[perm] = np.arange(num_samples_pad, dtype="int64")
+                perm_inv = paddle.to_tensor(perm_inv)
+                pred_dict = {
+                    key: value[perm_inv][:num_samples]
+                    for key, value in pred_dict.items()
+                }
 
         return pred_dict
 
@@ -599,7 +645,7 @@ class Solver:
             if not isinstance(ddp_model, paddle.DataParallel):
                 raise TypeError(
                     "no_sync interface is only for model with type paddle.DataParallel, "
-                    f"but got type {type(ddp_model)}"
+                    f"but got type {misc.typename(ddp_model)}"
                 )
             ctx_manager = ddp_model.no_sync()
         else:

--- a/ppsci/solver/visu.py
+++ b/ppsci/solver/visu.py
@@ -14,13 +14,17 @@
 
 import os
 import os.path as osp
+from typing import TYPE_CHECKING
 
 import paddle
+
+if TYPE_CHECKING:
+    from ppsci import solver
 
 from ppsci.utils import misc
 
 
-def visualize_func(solver, epoch_id: int):
+def visualize_func(solver: "solver.Solver", epoch_id: int):
     """Visualization program
 
     Args:

--- a/ppsci/utils/expression.py
+++ b/ppsci/utils/expression.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING
 from typing import Callable
 from typing import Dict
+from typing import Optional
 from typing import Tuple
 
 import paddle
@@ -121,23 +122,23 @@ class ExpressionSolver(nn.Layer):
 
     def visu_forward(
         self,
-        expr_dict: Dict[str, Callable],
+        expr_dict: Optional[Dict[str, Callable]],
         input_dict: Dict[str, paddle.Tensor],
         model: nn.Layer,
     ):
         # model forward
-        if callable(next(iter(expr_dict.values()))):
-            output_dict = model(input_dict)
+        output_dict = model(input_dict)
 
-        # equation forward
-        for name, expr in expr_dict.items():
-            if callable(expr):
-                output_dict[name] = expr({**output_dict, **input_dict})
-            else:
-                raise TypeError(f"expr type({type(expr)}) is invalid")
+        if isinstance(expr_dict, dict):
+            # equation forward
+            for name, expr in expr_dict.items():
+                if callable(expr):
+                    output_dict[name] = expr({**output_dict, **input_dict})
+                else:
+                    raise TypeError(f"expr type({type(expr)}) is invalid")
 
-        # clear differentiation cache
-        clear()
+            # clear differentiation cache
+            clear()
 
         # compute loss for each validator according to its' own output, label and weight
         return output_dict

--- a/ppsci/utils/misc.py
+++ b/ppsci/utils/misc.py
@@ -19,6 +19,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Tuple
+from typing import Union
 
 import numpy as np
 import paddle
@@ -121,7 +122,7 @@ def convert_to_dict(array: np.ndarray, keys: Tuple[str, ...]) -> Dict[str, np.nd
 
 def all_gather(
     tensor: paddle.Tensor, concat: bool = True, axis: int = 0
-) -> List[paddle.Tensor]:
+) -> Union[paddle.Tensor, List[paddle.Tensor]]:
     """Gather tensor from all devices, concatenate them along given axis if specified.
 
     Args:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 支持多卡 python 推理，完善几处 typehint 和 docstring
多卡 python 推理主要步骤：
    - step1 pad，将输入数据的数量，补齐到能被卡数整除
    - step2 shard，均匀切分数据到每张卡上（step1 保证了数据能被均匀切分，不均匀切分可能会在 all_gather 时 hang 住）
    - step3 local batch predict，每张卡根据切分得到的数据，并根据设置的 batch size，逐 batch 前向预测
    - step4 local batch concat，每张卡上各自拼接batch wise的预测结果
    - step5 all gather(and concat)，每张卡拿到所有卡上的预测结果并再次拼接
    - step6 rearange，根据数据切分产生的数据下标置换 $p$，求出其逆置换 $inv(p)$，将数据按逆置换排列，恢复顺序，与 input_dict 内的数据一一对应
    - step7 discard pad，重新排列完毕之后，丢弃末尾的对应pad数据的冗余预测结果
    - step8 return result，返回推理结果


正确性验证代码（num_samples=3+n_gpu=1,..,7+batch_size=31，num_samples=1153+n_gpu=1,...,7 +batch_size=31 的环境下均验证通过）：
``` python
import ppsci
import paddle

def run():
    paddle.seed(42)

    # N = 1153
    bs = 31
    # x = paddle.randn([N, 1])
    # x.stop_gradient = False
    # y = paddle.randn([N, 1])
    # y.stop_gradient = False
    # z = paddle.randn([N, 1])
    # z.stop_gradient = False
    # input_dict = {
    #     "x": x,
    #     "y": y,
    #     "z": z,
    # }


    input_dict = paddle.load("./input_dict.pddata")
    for v in input_dict.values():
        v.stop_gradient = False

    model = ppsci.arch.MLP(
        tuple(input_dict.keys()),
        ("u", "v", "w", "p"),
        5,
        64,
    )

    solver = ppsci.solver.Solver(
        model,
        seed=42,
        equation=eq.equations,
    )

    output_dict = solver.predict(
        input_dict,
        None,
        bs,
        False,
    )
    world_size = paddle.distributed.get_world_size()
    paddle.save(output_dict, f"output_dict_N1C{world_size}.pddata")


def check():
    n1c1 = paddle.load("./output_dict_N1C1.pddata")
    n1c2 = paddle.load("./output_dict_N1C2.pddata")
    n1c3 = paddle.load("./output_dict_N1C3.pddata")
    n1c4 = paddle.load("./output_dict_N1C4.pddata")
    n1c5 = paddle.load("./output_dict_N1C5.pddata")
    n1c6 = paddle.load("./output_dict_N1C6.pddata")
    n1c7 = paddle.load("./output_dict_N1C7.pddata")
    for k in n1c1:
        # 多卡通讯有微量误差，此处需设置atol=1e-7
        print(paddle.allclose(n1c1[k], n1c2[k], atol=1e-7).item())
        print(paddle.allclose(n1c1[k], n1c3[k], atol=1e-7).item())
        print(paddle.allclose(n1c1[k], n1c4[k], atol=1e-7).item())
        print(paddle.allclose(n1c1[k], n1c5[k], atol=1e-7).item())
        print(paddle.allclose(n1c1[k], n1c6[k], atol=1e-7).item())
        print(paddle.allclose(n1c1[k], n1c7[k], atol=1e-7).item())

if __name__ == "__main__":
    # run()
    check()
```

``` shell
python test_multigpu_predict.py
python -m paddle.distributed.launch --gpus=0,1 test_multigpu_predict.py
python -m paddle.distributed.launch --gpus=0,1,2 test_multigpu_predict.py
python -m paddle.distributed.launch --gpus=0,1,2,3 test_multigpu_predict.py
python -m paddle.distributed.launch --gpus=0,1,2,3,4 test_multigpu_predict.py
python -m paddle.distributed.launch --gpus=0,1,2,3,4,5 test_multigpu_predict.py
python -m paddle.distributed.launch --gpus=0,1,2,3,4,5,6 test_multigpu_predict.py
```

输出
``` shell
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
True
```