### PR TITLE
add judgment of dataloader's length

### DIFF
--- a/ppsci/data/__init__.py
+++ b/ppsci/data/__init__.py
@@ -106,4 +106,10 @@ def build_dataloader(_dataset, cfg):
         worker_init_fn=init_fn,
     )
 
+    if len(dataloader_) == 0:
+        raise ValueError(
+            f"batch_size({sampler_cfg['batch_size']}) should not bigger than number of "
+            f"samples({len(_dataset)}) when drop_last is {sampler_cfg.get('drop_last', False)}."
+        )
+
     return dataloader_


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add judgment of dataloader's length to avoid getting empty batch