### PR TITLE
add mathjax expression for equations and fix some code

### DIFF
--- a/ppsci/arch/mlp.py
+++ b/ppsci/arch/mlp.py
@@ -67,7 +67,7 @@ class MLP(base.Arch):
         activation (str, optional): Name of activation function. Defaults to "tanh".
         skip_connection (bool, optional): Whether to use skip connection. Defaults to False.
         weight_norm (bool, optional): Whether to apply weight norm on parameter(s). Defaults to False.
-        input_dim (Optional[int], optional): Number of input's dimension. Defaults to None.
+        input_dim (Optional[int]): Number of input's dimension. Defaults to None.
 
     Examples:
         >>> import ppsci

--- a/ppsci/autodiff/ad.py
+++ b/ppsci/autodiff/ad.py
@@ -171,12 +171,12 @@ class Hessians:
         Args:
             ys (paddle.Tensor): Output tensor.
             xs (paddle.Tensor): Input tensor.
-            component (Optional[int], optional): If `y` has the shape (batch_size, dim_y > 1), then `y[:, component]`
+            component (Optional[int]): If `y` has the shape (batch_size, dim_y > 1), then `y[:, component]`
                 is used to compute the Hessian. Do not use if `y` has the shape (batch_size,
                 1). Defaults to None.
             i (int, optional): i-th input variable. Defaults to 0.
             j (int, optional): j-th input variable. Defaults to 0.
-            grad_y (Optional[paddle.Tensor], optional): The gradient of `y` w.r.t. `xs`. Provide `grad_y` if known to avoid
+            grad_y (Optional[paddle.Tensor]): The gradient of `y` w.r.t. `xs`. Provide `grad_y` if known to avoid
                 duplicate computation. Defaults to None.
 
         Returns:

--- a/ppsci/equation/pde/biharmonic.py
+++ b/ppsci/equation/pde/biharmonic.py
@@ -17,7 +17,11 @@ from ppsci.equation.pde import base
 
 
 class Biharmonic(base.PDE):
-    """Class for biharmonic equation.
+    r"""Class for biharmonic equation.
+
+    $$
+    \nabla^4 \varphi = \dfrac{q}{D}
+    $$
 
     Args:
         dim (int): Dimension of equation.

--- a/ppsci/equation/pde/laplace.py
+++ b/ppsci/equation/pde/laplace.py
@@ -17,7 +17,11 @@ from ppsci.equation.pde import base
 
 
 class Laplace(base.PDE):
-    """Class for laplace equation.
+    r"""Class for laplace equation.
+
+    $$
+    \nabla^2 \varphi = 0
+    $$
 
     Args:
         dim (int): Dimension of equation.

--- a/ppsci/equation/pde/linear_elasticity.py
+++ b/ppsci/equation/pde/linear_elasticity.py
@@ -20,15 +20,29 @@ from ppsci.equation.pde import base
 
 
 class LinearElasticity(base.PDE):
-    """Linear elasticity equations.
+    r"""Linear elasticity equations.
     Use either (E, nu) or (lambda_, mu) to define the material properties.
+
+    $$
+    \begin{cases}
+        stress\_disp_{xx} = \lambda(\dfrac{\partial u}{\partial x} + \dfrac{\partial v}{\partial y} + \dfrac{\partial w}{\partial z}) + 2\mu \dfrac{\partial u}{\partial x} - \sigma_{xx} \\
+        stress\_disp_{yy} = \lambda(\dfrac{\partial u}{\partial x} + \dfrac{\partial v}{\partial y} + \dfrac{\partial w}{\partial z}) + 2\mu \dfrac{\partial v}{\partial y} - \sigma_{yy} \\
+        stress\_disp_{zz} = \lambda(\dfrac{\partial u}{\partial x} + \dfrac{\partial v}{\partial y} + \dfrac{\partial w}{\partial z}) + 2\mu \dfrac{\partial w}{\partial z} - \sigma_{zz} \\
+        traction_{x} = \mathbf{n}_x \sigma_{xx} + \mathbf{n}_y \sigma_{xy} + \mathbf{n}_z \sigma_{xz} \\
+        traction_{y} = \mathbf{n}_y \sigma_{yx} + \mathbf{n}_y \sigma_{yy} + \mathbf{n}_z \sigma_{yz} \\
+        traction_{z} = \mathbf{n}_z \sigma_{zx} + \mathbf{n}_y \sigma_{zy} + \mathbf{n}_z \sigma_{zz} \\
+        navier_{x} = \rho(\dfrac{\partial^2 u}{\partial t}) - (\lambda + \mu)(\dfrac{\partial^2 u}{\partial x^2}+\dfrac{\partial^2 v}{\partial y \partial x} + \dfrac{\partial^2 w}{\partial z \partial x}) - \mu(\dfrac{\partial^2 u}{\partial x^2} + \dfrac{\partial^2 u}{\partial y^2} + \dfrac{\partial^2 u}{\partial z^2}) \\
+        navier_{y} = \rho(\dfrac{\partial^2 v}{\partial t}) - (\lambda + \mu)(\dfrac{\partial^2 v}{\partial x \partial y}+\dfrac{\partial^2 v}{\partial y^2} + \dfrac{\partial^2 w}{\partial z \partial y}) - \mu(\dfrac{\partial^2 v}{\partial x^2} + \dfrac{\partial^2 v}{\partial y^2} + \dfrac{\partial^2 v}{\partial z^2}) \\
+        navier_{z} = \rho(\dfrac{\partial^2 w}{\partial t}) - (\lambda + \mu)(\dfrac{\partial^2 w}{\partial x \partial z}+\dfrac{\partial^2 v}{\partial y \partial z} + \dfrac{\partial^2 w}{\partial z^2}) - \mu(\dfrac{\partial^2 w}{\partial x^2} + \dfrac{\partial^2 w}{\partial y^2} + \dfrac{\partial^2 w}{\partial z^2}) \\
+    \end{cases}
+    $$
 
     Args:
         E (Optional[float]): The Young's modulus. Defaults to None.
         nu (Optional[float]): The Poisson's ratio. Defaults to None.
         lambda_ (Optional[float]): Lamé's first parameter. Defaults to None.
         mu (Optional[float]): Lamé's second parameter (shear modulus). Defaults to None.
-        rho (float, optional): Mass density.. Defaults to 1.
+        rho (float, optional): Mass density. Defaults to 1.
         dim (int, optional): Dimension of the linear elasticity (2 or 3). Defaults to 3.
         time (bool, optional): Whether contains time data. Defaults to False.
 

--- a/ppsci/equation/pde/navier_stokes.py
+++ b/ppsci/equation/pde/navier_stokes.py
@@ -18,7 +18,34 @@ from ppsci.equation.pde import base
 
 
 class NavierStokes(base.PDE):
-    """Class for navier-stokes equation.
+    r"""Class for navier-stokes equation.
+
+    $$
+    \begin{cases}
+        \dfrac{\partial u}{\partial x} + \dfrac{\partial v}{\partial y} + \dfrac{\partial w}{\partial z} = 0 \\
+        \dfrac{\partial u}{\partial t} + u\dfrac{\partial u}{\partial x} + v\dfrac{\partial u}{\partial y} + w\dfrac{\partial w}{\partial z} =
+            - \dfrac{1}{\rho}\dfrac{\partial p}{\partial x}
+            + \nu(
+                \dfrac{\partial ^2 u}{\partial x ^2}
+                + \dfrac{\partial ^2 u}{\partial y ^2}
+                + \dfrac{\partial ^2 u}{\partial z ^2}
+            ) \\
+        \dfrac{\partial v}{\partial t} + u\dfrac{\partial v}{\partial x} + v\dfrac{\partial v}{\partial y} + w\dfrac{\partial w}{\partial z} =
+            - \dfrac{1}{\rho}\dfrac{\partial p}{\partial y}
+            + \nu(
+                \dfrac{\partial ^2 v}{\partial x ^2}
+                + \dfrac{\partial ^2 v}{\partial y ^2}
+                + \dfrac{\partial ^2 v}{\partial z ^2}
+            ) \\
+        \dfrac{\partial w}{\partial t} + u\dfrac{\partial w}{\partial x} + v\dfrac{\partial w}{\partial y} + w\dfrac{\partial w}{\partial z} =
+            - \dfrac{1}{\rho}\dfrac{\partial p}{\partial z}
+            + \nu(
+                \dfrac{\partial ^2 w}{\partial x ^2}
+                + \dfrac{\partial ^2 w}{\partial y ^2}
+                + \dfrac{\partial ^2 w}{\partial z ^2}
+            ) \\
+    \end{cases}
+    $$
 
     Args:
         nu (float): Dynamic viscosity.
@@ -43,8 +70,7 @@ class NavierStokes(base.PDE):
             u, v = out["u"], out["v"]
             continuity = jacobian(u, x) + jacobian(v, y)
             if self.dim == 3:
-                z = out["z"]
-                w = out["w"]
+                z, w = out["z"], out["w"]
                 continuity += jacobian(w, z)
             return continuity
 
@@ -64,8 +90,7 @@ class NavierStokes(base.PDE):
                 t = out["t"]
                 momentum_x += jacobian(u, t)
             if self.dim == 3:
-                z = out["z"]
-                w = out["w"]
+                z, w = out["z"], out["w"]
                 momentum_x += w * jacobian(u, z)
                 momentum_x -= nu / rho * hessian(u, z)
             return momentum_x
@@ -86,8 +111,7 @@ class NavierStokes(base.PDE):
                 t = out["t"]
                 momentum_y += jacobian(v, t)
             if self.dim == 3:
-                z = out["z"]
-                w = out["w"]
+                z, w = out["z"], out["w"]
                 momentum_y += w * jacobian(v, z)
                 momentum_y -= nu / rho * hessian(v, z)
             return momentum_y

--- a/ppsci/equation/pde/normal_dot_vec.py
+++ b/ppsci/equation/pde/normal_dot_vec.py
@@ -18,7 +18,11 @@ from ppsci.equation.pde import base
 
 
 class NormalDotVec(base.PDE):
-    """NormalDotVec.
+    r"""NormalDotVec.
+
+    $$
+    \mathbf{n} \cdot \mathbf{v} = 0
+    $$
 
     Args:
         velocity_keys (Tuple[str, ...]): Keys for velocity(ies).

--- a/ppsci/equation/pde/poisson.py
+++ b/ppsci/equation/pde/poisson.py
@@ -17,7 +17,11 @@ from ppsci.equation.pde import base
 
 
 class Poisson(base.PDE):
-    """Class for poisson equation.
+    r"""Class for poisson equation.
+
+    $$
+    \nabla^2 \varphi = C
+    $$
 
     Args:
         dim (int): Dimension of equation.

--- a/ppsci/equation/pde/viv.py
+++ b/ppsci/equation/pde/viv.py
@@ -21,7 +21,11 @@ from ppsci.equation.pde import base
 
 
 class Vibration(base.PDE):
-    """Vortex induced vibration equation.
+    r"""Vortex induced vibration equation.
+
+    $$
+    \rho \dfrac{\partial^2 \eta}{\partial t^2} + e^{k1} \dfrac{\partial \eta}{\partial t} + e^{k2} \eta = f
+    $$
 
     Args:
         rho (float): Generalized mass.
@@ -37,12 +41,12 @@ class Vibration(base.PDE):
         super().__init__()
         self.rho = rho
         self.k1 = paddle.create_parameter(
-            shape=[1],
+            shape=[],
             dtype=paddle.get_default_dtype(),
             default_initializer=initializer.Constant(k1),
         )
         self.k2 = paddle.create_parameter(
-            shape=[1],
+            shape=[],
             dtype=paddle.get_default_dtype(),
             default_initializer=initializer.Constant(k2),
         )

--- a/ppsci/geometry/mesh.py
+++ b/ppsci/geometry/mesh.py
@@ -161,7 +161,7 @@ class Mesh(geometry.Geometry):
             open3d.utility.Vector3dVector(vertices),
             open3d.utility.Vector3iVector(faces),
         )
-        open3d_mesh.scale(scale, center)
+        open3d_mesh = open3d_mesh.scale(scale, center)
         self.py_mesh = pymesh.form_mesh(
             np.asarray(open3d_mesh.vertices, dtype=paddle.get_default_dtype()), faces
         )

--- a/ppsci/loss/integral.py
+++ b/ppsci/loss/integral.py
@@ -28,13 +28,13 @@ class IntegralLoss(base.Loss):
     $$
     L =
     \begin{cases}
-        \dfrac{1}{N} \Vert \mathbf{s} \circ \mathbf{x} - \mathbf{y} \Vert_2^2, & \text{if reduction='mean'} \\
-         \Vert \mathbf{s} \circ \mathbf{x} - \mathbf{y} \Vert_2^2, & \text{if reduction='sum'}
+        \dfrac{1}{N} \Vert \displaystyle\sum_{i=1}^{M}{\mathbf{s}_i \cdot \mathbf{x}_i} - \mathbf{y} \Vert_2^2, & \text{if reduction='mean'} \\
+         \Vert \displaystyle\sum_{i=0}^{M}{\mathbf{s}_i \cdot \mathbf{x}_i} - \mathbf{y} \Vert_2^2, & \text{if reduction='sum'}
     \end{cases}
     $$
 
     $$
-    \mathbf{x}, \mathbf{y}, \mathbf{s} \in \mathcal{R}^{N}
+    \mathbf{x}, \mathbf{s} \in \mathcal{R}^{M \times N}, \mathbf{y} \in \mathcal{R}^{N}
     $$
 
     Args:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs 
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 为 `Equation` 模块下的部分公式的 docstring 添加对应 mathjax 公式
2. 修复 `IntergralLoss` 公式描述错误的问题

其他：
1. 修复 `Mesh.scale` 未赋值回原变量导致该接口实际无效的问题
3. 优化几处接口的 docstring 和代码结构