### PR TITLE
add unit test for Laplace

### DIFF
--- a/test/equation/test_laplace.py
+++ b/test/equation/test_laplace.py
@@ -1,0 +1,65 @@
+import paddle
+import pytest
+from paddle import nn
+
+from ppsci import equation
+
+__all__ = []
+
+
+@pytest.mark.parametrize("dim", (2, 3))
+def test_l1loss_mean(dim):
+    """Test for only mean."""
+    batch_size = 13
+    input_dims = ("x", "y", "z")[:dim]
+    output_dims = ("u",)
+
+    # generate input data
+    x = paddle.randn([batch_size, 1])
+    y = paddle.randn([batch_size, 1])
+    x.stop_gradient = False
+    y.stop_gradient = False
+    input_data = paddle.concat([x, y], axis=1)
+    if dim == 3:
+        z = paddle.randn([batch_size, 1])
+        z.stop_gradient = False
+        input_data = paddle.concat([x, y, z], axis=1)
+
+    # build NN model
+    model = nn.Sequential(
+        nn.Linear(len(input_dims), len(output_dims)),
+        nn.Tanh(),
+    )
+
+    # manually generate output
+    u = model(input_data)
+
+    # use self-defined jacobian and hessian
+    def jacobian(y: "paddle.Tensor", x: "paddle.Tensor") -> "paddle.Tensor":
+        return paddle.grad(y, x, create_graph=True)[0]
+
+    def hessian(y: "paddle.Tensor", x: "paddle.Tensor") -> "paddle.Tensor":
+        return jacobian(jacobian(y, x), x)
+
+    # compute expected result
+    expected_result = hessian(u, x) + hessian(u, y)
+    if dim == 3:
+        expected_result += hessian(u, z)
+
+    # compute result using built-in Laplace module
+    laplace_equation = equation.Laplace(dim=dim)
+    data_dict = {
+        "x": x,
+        "y": y,
+        "u": u,
+    }
+    if dim == 3:
+        data_dict["z"] = z
+    test_result = laplace_equation.equations["laplace"](data_dict)
+
+    # check result whether is equal
+    assert paddle.allclose(expected_result, test_result)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 

### Describe
<!-- Describe what this PR does -->
主要修改点：为 ppsci.equation.pde.Laplace 类添加单元测试

``` sh
# 执行单元测试并报告覆盖率
pytest --cov=./ppsci/equation/pde test/equation/test_laplace.py
```

``` sh
platform linux -- Python 3.7.16, pytest-7.3.1, pluggy-1.0.0
rootdir: /workspace/hesensen/PaddleScience
plugins: anyio-3.6.2, dash-2.9.2, cov-4.1.0
collected 2 items                                                                                                                                                              

test/equation/test_laplace.py ..                                                                                                                                         [100%]

---------- coverage: platform linux, python 3.7.16-final-0 -----------
Name                                      Stmts   Miss  Cover
-------------------------------------------------------------
ppsci/equation/pde/__init__.py                9      0   100%
ppsci/equation/pde/base.py                   26      6    77%
ppsci/equation/pde/biharmonic.py             17     13    24%
ppsci/equation/pde/laplace.py                15      0   100%
ppsci/equation/pde/linear_elasticity.py     155    149     4%
ppsci/equation/pde/navier_stokes.py          60     53    12%
ppsci/equation/pde/normal_dot_vec.py         13      9    31%
ppsci/equation/pde/poisson.py                13      9    31%
ppsci/equation/pde/viv.py                    20     13    35%
-------------------------------------------------------------
TOTAL                                       328    252    23%
```
