### PR TITLE
[Feature] Add rectangle and triangle sdf_func

### DIFF
--- a/ppsci/geometry/geometry_2d.py
+++ b/ppsci/geometry/geometry_2d.py
@@ -182,10 +182,10 @@ class Rectangle(geometry_nd.Hypercube):
 
         Args:
             points (np.ndarray): The coordinate points used to calculate the SDF value,
-                the shape of the array is `[N, 2]`.
+                the shape of the array is [N, 2].
 
         Returns:
-            np.ndarray: Unsquared SDF values of input points, the shape is `[N, 1]`.
+            np.ndarray: Unsquared SDF values of input points, the shape is [N, 1].
 
         NOTE: This function usually returns ndarray with negative values, because
         according to the definition of SDF, the SDF value of the coordinate point inside
@@ -193,11 +193,17 @@ class Rectangle(geometry_nd.Hypercube):
         is 0. Therefore, when used for weighting, a negative sign is often added before
         the result of this function.
         """
-        assert points.shape[1] == 2, "The shape of points must be [N, 2]."
+        if points.shape[1] != 2:
+            raise ValueError(
+                f"Shape of given points should be [*, 2], but got {points.shape}"
+            )
         center = (self.xmin + self.xmax) / 2
-        q = np.abs(points - center) - np.array([self.xmax - self.xmin]) / 2
+        dist_from_center = (
+            np.abs(points - center) - np.array([self.xmax - self.xmin]) / 2
+        )
         return -(
-            np.linalg.norm(np.maximum(q, 0), axis=1) + np.minimum(np.max(q, axis=1), 0)
+            np.linalg.norm(np.maximum(dist_from_center, 0), axis=1)
+            + np.minimum(np.max(dist_from_center, axis=1), 0)
         ).reshape(-1, 1)
 
 
@@ -377,10 +383,10 @@ class Triangle(geometry.Geometry):
 
         Args:
             points (np.ndarray): The coordinate points used to calculate the SDF value,
-                the shape of the array is `[N, 2]`.
+                the shape of the array is [N, 2].
 
         Returns:
-            np.ndarray: Unsquared SDF values of input points, the shape is `[N, 1]`.
+            np.ndarray: Unsquared SDF values of input points, the shape is [N, 1].
 
         NOTE: This function usually returns ndarray with negative values, because
         according to the definition of SDF, the SDF value of the coordinate point inside
@@ -388,32 +394,36 @@ class Triangle(geometry.Geometry):
         is 0. Therefore, when used for weighting, a negative sign is often added before
         the result of this function.
         """
-        assert points.shape[1] == 2, "The shape of points must be [N, 2]."
-        v1p = points - self.x1
+        if points.shape[1] != 2:
+            raise ValueError(
+                f"Shape of given points should be [*, 2], but got {points.shape}"
+            )
+        v1p = points - self.x1  # v1p: vector from x1 to points
         v2p = points - self.x2
         v3p = points - self.x3
-        pq1 = (
+        # vv12_p: vertical vector of points to v12(If the vertical point is in the extension of v12,
+        # the vector will be the vector from x1 to points)
+        vv12_p = (
             self.v12
             * np.clip(np.dot(v1p, self.v12.reshape(2, -1)) / self.l12**2, 0, 1)
             - v1p
         )
-        pq2 = (
+        vv23_p = (
             self.v23
             * np.clip(np.dot(v2p, self.v23.reshape(2, -1)) / self.l23**2, 0, 1)
             - v2p
         )
-        pq3 = (
+        vv31_p = (
             self.v31
             * np.clip(np.dot(v3p, self.v31.reshape(2, -1)) / self.l31**2, 0, 1)
             - v3p
         )
-
-        s = self.is_inside(points).reshape(-1, 1) * 2 - 1
-        dist_pq1 = np.linalg.norm(pq1, axis=1, keepdims=True)
-        dist_pq2 = np.linalg.norm(pq2, axis=1, keepdims=True)
-        dist_pq3 = np.linalg.norm(pq3, axis=1, keepdims=True)
-        dist = np.minimum(np.minimum(dist_pq1, dist_pq2), dist_pq3)
-        return s * dist
+        is_inside = self.is_inside(points).reshape(-1, 1) * 2 - 1
+        len_vv12_p = np.linalg.norm(vv12_p, axis=1, keepdims=True)
+        len_vv23_p = np.linalg.norm(vv23_p, axis=1, keepdims=True)
+        len_vv31_p = np.linalg.norm(vv31_p, axis=1, keepdims=True)
+        mini_dist = np.minimum(np.minimum(len_vv12_p, len_vv23_p), len_vv31_p)
+        return is_inside * mini_dist
 
 
 class Polygon(geometry.Geometry):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
New features

### PR changes
APIs

### Describe

In this pull request, I have added the sdf_func implementations for rectangles and triangles. The visual result can be tested using the following code:

```python
import ppsci
import numpy as np

from matplotlib import pyplot as plt

geo = ppsci.geometry.Triangle((0, 0), (1, 0), (0, 1))

x = np.linspace(-0.5, 1.3, 1000)
y = np.linspace(-0.5, 1.3, 1000)
X, Y = np.meshgrid(x, y)
x = X.flatten()
y = Y.flatten()
Z = geo.sdf_func(np.stack([x, y], axis=-1)).reshape(X.shape)
plt.contour(X, Y, Z, 0, colors="black")
plt.contourf(X, Y, Z, 20, cmap="RdBu_r")
plt.colorbar()
plt.show()
```

**Visual Result** 

![output](https://github.com/PaddlePaddle/PaddleScience/assets/27223114/51990c86-bbaa-49fb-8b4b-9d246c485e17)
![output1](https://github.com/PaddlePaddle/PaddleScience/assets/27223114/deab8842-288d-46fc-b64c-65153182b517)

https://github.com/PaddlePaddle/PaddleScience/issues/376