### PR TITLE
add unit test for normal_dot_vec

### DIFF
--- a/test/equation/test_normal_dot_vec.py
+++ b/test/equation/test_normal_dot_vec.py
@@ -1,0 +1,39 @@
+import paddle
+import pytest
+
+from ppsci import equation
+
+
+def compute_func(x: tuple, y: tuple):
+    z_i = paddle.zeros_like(x[0])
+    for x_i, y_i in zip(x, y):
+        z_i += x_i * y_i
+    return z_i
+
+
+def test_normal_dot_vel():
+    batch_size = 13
+    u = paddle.randn([batch_size, 1])
+    v = paddle.randn([batch_size, 1])
+    w = paddle.randn([batch_size, 1])
+
+    normal_x = paddle.randn([batch_size, 1])
+    normal_y = paddle.randn([batch_size, 1])
+    normal_z = paddle.randn([batch_size, 1])
+
+    pde = equation.NormalDotVec(("u", "v", "w"))
+    out = {
+        "u": u,
+        "v": v,
+        "w": w,
+        "normal_x": normal_x,
+        "normal_y": normal_y,
+        "normal_z": normal_z,
+    }
+
+    expected_result = compute_func((u, v, w), (normal_x, normal_y, normal_z))
+    assert paddle.allclose(pde.equations["normal_dot_vel"](out), expected_result)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
add unit test for `normal_dot_vec.py`

```
pytest --cov=./ppsci/equation/pde test/equation/test_normal_dot_vec.py
========================================================= test session starts ==========================================================
platform linux -- Python 3.10.6, pytest-7.3.2, pluggy-1.0.0
rootdir: /home/greatx/repos/PaddleScience
plugins: anyio-3.7.0, cov-4.1.0
collected 1 item                                                                                                                       

test/equation/test_normal_dot_vec.py .                                                                                           [100%]

---------- coverage: platform linux, python 3.10.6-final-0 -----------
Name                                      Stmts   Miss  Cover
-------------------------------------------------------------
ppsci/equation/pde/__init__.py                9      0   100%
ppsci/equation/pde/base.py                   26      7    73%
ppsci/equation/pde/biharmonic.py             17     13    24%
ppsci/equation/pde/laplace.py                15     11    27%
ppsci/equation/pde/linear_elasticity.py     155    149     4%
ppsci/equation/pde/navier_stokes.py          60     53    12%
ppsci/equation/pde/normal_dot_vec.py         13      0   100%
ppsci/equation/pde/poisson.py                13      9    31%
ppsci/equation/pde/viv.py                    20     13    35%
-------------------------------------------------------------
TOTAL                                       328    255    22%


========================================================== 1 passed in 4.36s ===========================================================


```