### PR TITLE
[Feature] Add disk sdf_func

### DIFF
--- a/ppsci/geometry/geometry_2d.py
+++ b/ppsci/geometry/geometry_2d.py
@@ -78,6 +78,26 @@ class Disk(geometry.Geometry):
         X = np.concatenate((np.cos(theta), np.sin(theta)), axis=1)
         return self.radius * X + self.center
 
+    def sdf_func(self, points: np.ndarray) -> np.ndarray:
+        """Compute signed distance field.
+
+        Args:
+            points (np.ndarray): The coordinate points used to calculate the SDF value,
+                the shape is [N, 2]
+
+        Returns:
+            np.ndarray: Unsquared SDF values of input points, the shape is [N, 1].
+
+        NOTE: This function usually returns ndarray with negative values, because
+        according to the definition of SDF, the SDF value of the coordinate point inside
+        the object(interior points) is negative, the outside is positive, and the edge
+        is 0. Therefore, when used for weighting, a negative sign is often added before
+        the result of this function.
+        """
+        sdf = self.radius - np.linalg.norm(points - self.center, axis=1)
+        sdf = -sdf[..., np.newaxis]
+        return sdf
+
 
 class Rectangle(geometry_nd.Hypercube):
     """Class for rectangle geometry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,4 +64,4 @@ exclude = ["docs*", "examples*", "jointContribution*", "test_tipc*", "tests*", "
 
 [tool.ruff]
 line-length = 88
-ignore = ["E501",]
+ignore = ["E501", "E741"]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
#376 
In this pull request, I have added the sdf_func implementations for disk The visual result can be tested using the following code:

~~~python
import os
print(os.environ['PYTHONPATH'])
import ppsci

from ppsci import visualize

geo = ppsci.geometry.Disk((0.0, 0.0), 1.0)
points_dict = geo.sample_interior(n=10000) # 可视化10000个点
visualize.vtu.save_vtu_from_dict("./visualize_sdf.vtu", points_dict, geo.dim_keys, ("sdf", ))
~~~

### Visual Result
Visualize results with ParaView software:
![图1](https://github.com/PaddlePaddle/PaddleScience/assets/88936287/5a0c5303-ccae-4239-8179-153396993975)
![图2](https://github.com/PaddlePaddle/PaddleScience/assets/88936287/b9ab8d08-e228-4070-ba7e-bfc5edbf6b4f)

Also, add ignore:"E741" for tool.ruff