### PR TITLE
Adding unittest for equation/pde/base.py

### DIFF
--- a/test/equation/test_pde_base.py
+++ b/test/equation/test_pde_base.py
@@ -1,7 +1,8 @@
-import pytest
 import paddle
+import pytest
 import sympy
 from paddle import nn
+
 from ppsci.equation import PDE
 
 

--- a/test/equation/test_pde_base.py
+++ b/test/equation/test_pde_base.py
@@ -126,7 +126,7 @@ class Test_PDE:
         def simple_equation(out):
             x, y = out["x"], out["y"]
             return x + y
-        
+
         pde.add_equation("simple", simple_equation)
 
         assert str(pde).startswith("PDE, simple: ")

--- a/test/equation/test_pde_base.py
+++ b/test/equation/test_pde_base.py
@@ -1,0 +1,121 @@
+import pytest
+import paddle
+import sympy
+from paddle import nn
+from ppsci.equation import PDE
+
+
+class Test_PDE:
+    def test_pde_init(self):
+        """
+        Testing the PDE class initialization
+        """
+        pde = PDE()
+        assert isinstance(pde, PDE)
+        assert isinstance(pde.equations, dict)
+        assert isinstance(pde.learnable_parameters, nn.ParameterList)
+
+    def test_pde_add_equation(self):
+        """
+        initiate a PDE object and add an equation to it
+        """
+        pde = PDE()
+
+        def simple_equation(out):
+            x, y = out["x"], out["y"]
+            return x + y
+
+        pde.add_equation("simple", simple_equation)
+
+        assert "simple" in pde.equations
+        assert pde.equations["simple"] == simple_equation
+        assert pde.equations["simple"]({"x": 1, "y": 2}) == 3
+
+        # redefine the equation and add again
+        def simple_equation2(out):
+            x, y = out["x"], out["y"]
+            return x - y
+
+        pde.add_equation("simple", simple_equation2)
+
+        assert pde.equations["simple"] == simple_equation2
+        assert pde.equations["simple"]({"x": 1, "y": 2}) == -1
+
+    def test_pde_create_symbols(self):
+        """
+        initiate a PDE object and add three symbols to it
+        """
+        pde = PDE()
+
+        # create symbols
+        x, y, z = pde.create_symbols("x y z")
+        assert isinstance(x, sympy.Symbol)
+        assert isinstance(y, sympy.Symbol)
+        assert isinstance(z, sympy.Symbol)
+
+    def test_pde_create_function(self):
+        """
+        initiate a PDE object and add a symbolic function to it
+        """
+        pde = PDE()
+
+        # create symbols
+        x, y, z = pde.create_symbols("x y z")
+
+        # create a function
+        f = pde.create_function(name="f", invars=(x, y, z))
+        assert isinstance(f, sympy.Function)
+        assert f.args == (x, y, z)
+
+    def test_pde_parameters(self):
+        """
+        initiate a PDE object and add a learnable parameter to it
+        """
+        pde = PDE()
+
+        assert len(pde.parameters()) == 0
+
+        # add a learnable parameter
+        pde.learnable_parameters.append(
+            paddle.create_parameter(shape=[1], dtype="float32")
+        )
+
+        assert len(pde.parameters()) == 1
+
+    def test_pde_state_dict(self):
+        """
+        initiate a PDE object, add a learnable parameter to it and check its state dict
+        """
+        pde = PDE()
+
+        assert len(pde.state_dict()) == 0
+
+        # add a learnable parameter
+        pde.learnable_parameters.append(
+            paddle.create_parameter(shape=[1], dtype="float32")
+        )
+
+        assert len(pde.state_dict()) == 1
+
+    def test_pde_set_state_dict(self):
+        """
+        initiate a PDE object, set its state dict and check its state dict
+        """
+        pde = PDE()
+
+        assert len(pde.state_dict()) == 0
+
+        external_state = {
+            "learnable_parameters": [
+                paddle.create_parameter(shape=[1], dtype="float32")
+            ]
+        }
+
+        # set state dict
+        pde.set_state_dict(pde.state_dict())
+
+        assert len(pde.state_dict()) == 1
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/equation/test_pde_base.py
+++ b/test/equation/test_pde_base.py
@@ -115,8 +115,6 @@ class Test_PDE:
         pde.learnable_parameters.set_state_dict(external_state)
         assert pde.state_dict()["0"] == paddle.to_tensor([2.0])
 
-        
-
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/equation/test_pde_base.py
+++ b/test/equation/test_pde_base.py
@@ -105,17 +105,17 @@ class Test_PDE:
         pde = PDE()
 
         assert len(pde.state_dict()) == 0
+        # this is a paddle nn.ParameterList()
+        pde.learnable_parameters.append(
+            paddle.create_parameter(shape=[1], dtype="float32")
+        )
+        external_state = pde.state_dict()
+        # change the value in the external_state to 2
+        external_state["0"] = paddle.to_tensor([2.0])
+        pde.learnable_parameters.set_state_dict(external_state)
+        assert pde.state_dict()["0"] == paddle.to_tensor([2.0])
 
-        external_state = {
-            "learnable_parameters": [
-                paddle.create_parameter(shape=[1], dtype="float32")
-            ]
-        }
-
-        # set state dict
-        pde.set_state_dict(pde.state_dict())
-
-        assert len(pde.state_dict()) == 1
+        
 
 
 if __name__ == "__main__":

--- a/test/equation/test_pde_base.py
+++ b/test/equation/test_pde_base.py
@@ -112,8 +112,24 @@ class Test_PDE:
         external_state = pde.state_dict()
         # change the value in the external_state to 2
         external_state["0"] = paddle.to_tensor([2.0])
-        pde.learnable_parameters.set_state_dict(external_state)
+        pde.set_state_dict(external_state)
         assert pde.state_dict()["0"] == paddle.to_tensor([2.0])
+
+    def test_str(self):
+        """
+        initiate a PDE object and check its string representation
+        """
+        pde = PDE()
+        assert str(pde) == "PDE"
+
+        # add an equation
+        def simple_equation(out):
+            x, y = out["x"], out["y"]
+            return x + y
+        
+        pde.add_equation("simple", simple_equation)
+
+        assert str(pde).startswith("PDE, simple: ")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
Others

### PR changes
Others

### Describe
Adding unittest for equation/pde/base.py

```
---------- coverage: platform win32, python 3.9.13-final-0 -----------
Name                                                                                          Stmts   Miss  Cover
-----------------------------------------------------------------------------------------------------------------
C:\Users\kinet\anaconda3\envs\paddle\Lib\site-packages\ppsci\equation\pde\__init__.py             8      0   100%
C:\Users\kinet\anaconda3\envs\paddle\Lib\site-packages\ppsci\equation\pde\base.py                26      0   100%
C:\Users\kinet\anaconda3\envs\paddle\Lib\site-packages\ppsci\equation\pde\biharmonic.py          17     13    24%
C:\Users\kinet\anaconda3\envs\paddle\Lib\site-packages\ppsci\equation\pde\laplace.py             15     11    27%
C:\Users\kinet\anaconda3\envs\paddle\Lib\site-packages\ppsci\equation\pde\navier_stokes.py       58     53     9%
C:\Users\kinet\anaconda3\envs\paddle\Lib\site-packages\ppsci\equation\pde\normal_dot_vec.py      13      9    31%
C:\Users\kinet\anaconda3\envs\paddle\Lib\site-packages\ppsci\equation\pde\poisson.py             13      9    31%
C:\Users\kinet\anaconda3\envs\paddle\Lib\site-packages\ppsci\equation\pde\viv.py                 20     13    35%
-----------------------------------------------------------------------------------------------------------------
TOTAL                                                                                           170    108    36%

============================================================================================================================ 8 passed, 3 warnings in 6.20s
```