### PR TITLE
add test for poisson

### DIFF
--- a/test/equation/test_poisson.py
+++ b/test/equation/test_poisson.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import pytest
+from paddle import nn
+
+from ppsci import equation
+
+__all__ = []
+
+
+@pytest.mark.parametrize("dim", (2, 3))
+def test_poisson(dim):
+    """Test for only mean."""
+    batch_size = 13
+    input_dims = ("x", "y", "z")[:dim]
+    output_dims = ("p",)
+
+    # generate input data
+    x = paddle.randn([batch_size, 1])
+    y = paddle.randn([batch_size, 1])
+    x.stop_gradient = False
+    y.stop_gradient = False
+    input_data = paddle.concat([x, y], axis=1)
+    if dim == 3:
+        z = paddle.randn([batch_size, 1])
+        z.stop_gradient = False
+        input_data = paddle.concat([x, y, z], axis=1)
+
+    # build NN model
+    model = nn.Sequential(
+        nn.Linear(len(input_dims), len(output_dims)),
+        nn.Tanh(),
+    )
+
+    # manually generate output
+    p = model(input_data)
+
+    def jacobian(y: paddle.Tensor, x: paddle.Tensor) -> paddle.Tensor:
+        return paddle.grad(y, x, create_graph=True)[0]
+
+    def hessian(y: paddle.Tensor, x: paddle.Tensor) -> paddle.Tensor:
+        return jacobian(jacobian(y, x), x)
+
+    # compute expected result
+    expected_result = hessian(p, x) + hessian(p, y)
+    if dim == 3:
+        expected_result += hessian(p, z)
+
+    # compute result using built-in Laplace module
+    poisson_equation = equation.Poisson(dim=dim)
+    data_dict = {
+        "x": x,
+        "y": y,
+        "p": p,
+    }
+    if dim == 3:
+        data_dict["z"] = z
+    test_result = poisson_equation.equations["poisson"](data_dict)
+    # check result whether is equal
+    assert paddle.allclose(expected_result, test_result)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/PaddleScience/issues/378 3.6 poisson
add unit test for poisson

```bash
aistudio@jupyter-115720-6409174:~/PaddleScience$ pytest --cov=./ppsci/equation/pde test/equation/test_poisson.py
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/aistudio/PaddleScience
plugins: anyio-3.7.0, cov-4.1.0
collected 2 items                                                                                                                                                      

test/equation/test_poisson.py ..                                                                                                                                 [100%]

----------- coverage: platform linux, python 3.8.8-final-0 -----------
Name                                      Stmts   Miss  Cover
-------------------------------------------------------------
ppsci/equation/pde/__init__.py                9      0   100%
ppsci/equation/pde/base.py                   26      6    77%
ppsci/equation/pde/biharmonic.py             17     13    24%
ppsci/equation/pde/laplace.py                15     11    27%
ppsci/equation/pde/linear_elasticity.py     155    149     4%
ppsci/equation/pde/navier_stokes.py          60     53    12%
ppsci/equation/pde/normal_dot_vec.py         13      9    31%
ppsci/equation/pde/poisson.py                13      0   100%
ppsci/equation/pde/viv.py                    20     13    35%
-------------------------------------------------------------
TOTAL                                       328    254    23%


========================================================================== 2 passed in 3.86s ===========================================================================
```