### PR TITLE
Add sdf for bool operation for simple geometries

### DIFF
--- a/ppsci/geometry/csg.py
+++ b/ppsci/geometry/csg.py
@@ -117,6 +117,21 @@ class CSGUnion(geometry.Geometry):
         ]
         return x
 
+    def sdf_func(self, points: np.ndarray) -> np.ndarray:
+        """Compute signed distance field of CSG union of two geometries.
+        ref: https://iquilezles.org/articles/distfunctions/
+
+        Args:
+            points (np.ndarray): The coordinate points used to calculate the SDF
+            value, the shape is [N, D].
+
+        Returns:
+            np.ndarray: Unsquared SDF values of input points, the shape is [N, D].
+        """
+        sdf1 = self.geom1.sdf_func(points)
+        sdf2 = self.geom2.sdf_func(points)
+        return np.minimum(sdf1, sdf2)
+
 
 class CSGDifference(geometry.Geometry):
     """Construct an object by CSG Difference."""
@@ -196,6 +211,21 @@ class CSGDifference(geometry.Geometry):
             on_boundary_geom1
         ]
         return x
+
+    def sdf_func(self, points: np.ndarray) -> np.ndarray:
+        """Compute signed distance field of CSG difference of two geometries.
+        ref: https://iquilezles.org/articles/distfunctions/
+
+        Args:
+            points (np.ndarray): The coordinate points used to calculate the SDF
+            value, the shape is [N, D].
+
+        Returns:
+            np.ndarray: Unsquared SDF values of input points, the shape is [N, D].
+        """
+        sdf1 = self.geom1.sdf_func(points)
+        sdf2 = self.geom2.sdf_func(points)
+        return np.maximum(sdf1, -sdf2)
 
 
 class CSGIntersection(geometry.Geometry):
@@ -289,3 +319,18 @@ class CSGIntersection(geometry.Geometry):
             on_boundary_geom2
         ]
         return x
+
+    def sdf_func(self, points: np.ndarray) -> np.ndarray:
+        """Compute signed distance field of CSG intersection of two geometries.
+        ref: https://iquilezles.org/articles/distfunctions/
+
+        Args:
+            points (np.ndarray): The coordinate points used to calculate the SDF
+            value the shape is [N, D].
+
+        Returns:
+            np.ndarray: Unsquared SDF values of input points, the shape is [N, D].
+        """
+        sdf1 = self.geom1.sdf_func(points)
+        sdf2 = self.geom2.sdf_func(points)
+        return np.maximum(sdf1, sdf2)

--- a/ppsci/geometry/geometry_1d.py
+++ b/ppsci/geometry/geometry_1d.py
@@ -109,8 +109,5 @@ class Interval(geometry.Geometry):
         the object(interior points) is negative, the outside is positive, and the edge
         is 0. Therefore, when used for weighting, a negative sign is often added before
         the result of this function.
-
-        For interval with [l, r], the sdf is defined by:
-            sdf(x) = -min(x-l, r-x) = ((r-l)/2 - abs(x-(l+r)/2))/2
         """
-        return ((self.r - self.l) / 2 - np.abs(points - (self.l + self.r) / 2)) / 2
+        return -((self.r - self.l) / 2 - np.abs(points - (self.l + self.r) / 2))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 为简单几何的 CSG 布尔操作添加 sdf_func 的运算
2. 修复 `Interval` 几何 sdf_func 计算错误的问题