### PR TITLE
Automatically initialize logger when it is not initialized

### DIFF
--- a/ppsci/utils/logger.py
+++ b/ppsci/utils/logger.py
@@ -113,21 +113,47 @@ def log_at_trainer0(log_func):
     return wrapped_log_func
 
 
+def ensure_logger(log_func):
+    """
+    Automatically initialize `logger` by default arguments
+    when init_logger() is not called manually.
+    """
+
+    @functools.wraps(log_func)
+    def wrapped_log_func(fmt, *args):
+        if _logger is None:
+            init_logger()
+            _logger.info(
+                "Before you call functions within the logger, the logger has already "
+                "been automatically initialized. Since `log_file` is not specified by "
+                "default, information will not be written to any file except being "
+                "output to the terminal."
+            )
+
+        log_func(fmt, *args)
+
+    return wrapped_log_func
+
+
+@ensure_logger
 @log_at_trainer0
 def info(fmt, *args):
     _logger.info(fmt, *args)
 
 
+@ensure_logger
 @log_at_trainer0
 def debug(fmt, *args):
     _logger.debug(fmt, *args)
 
 
+@ensure_logger
 @log_at_trainer0
 def warning(fmt, *args):
     _logger.warning(fmt, *args)
 
 
+@ensure_logger
 @log_at_trainer0
 def error(fmt, *args):
     _logger.error(fmt, *args)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 为了避免用户在调试过程中，使用`logger`模块打印信息，或者内部的一些日志调用`logger`之前，还需手动调用`logger.init_logger`这一函数否则会报错的问题，减少不必要的代码量，提升用户体验。因此在调用`logger`模块下的日志打印函数之前，若未手动调用`init_logger`对全局单例`_logger`进行初始化，则自动调用`init_logger`进行初始化，但由于自动初始化的`log_file`为未指定的None，因此只会打印信息到终端，而不会同步输出到文件中。