### PR TITLE
[Fix] Fix to static failure for wrong type of expr_dicts

### DIFF
--- a/ppsci/solver/train.py
+++ b/ppsci/solver/train.py
@@ -36,6 +36,9 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
     """
     batch_tic = time.perf_counter()
 
+    expr_dicts = tuple(
+        _constraint.output_expr for _constraint in solver.constraint.values()
+    )
     for iter_id in range(1, solver.iters_per_epoch + 1):
         total_loss = 0
         loss_dict = misc.Prettydefaultdict(float)
@@ -75,10 +78,7 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
             # forward for every constraint, including model and equation expression
             with solver.autocast_context_manager(solver.use_amp, solver.amp_level):
                 constraint_losses = solver.forward_helper.train_forward(
-                    (
-                        _constraint.output_expr
-                        for _constraint in solver.constraint.values()
-                    ),
+                    expr_dicts,
                     input_dicts,
                     solver.model,
                     solver.constraint,
@@ -144,6 +144,9 @@ def train_LBFGS_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int
     """
     batch_tic = time.perf_counter()
 
+    expr_dicts = tuple(
+        _constraint.output_expr for _constraint in solver.constraint.values()
+    )
     for iter_id in range(1, solver.iters_per_epoch + 1):
         loss_dict = misc.Prettydefaultdict(float)
         loss_dict["loss"] = 0.0
@@ -183,10 +186,7 @@ def train_LBFGS_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int
                 with solver.autocast_context_manager(solver.use_amp, solver.amp_level):
                     # forward for every constraint, including model and equation expression
                     constraint_losses = solver.forward_helper.train_forward(
-                        (
-                            _constraint.output_expr
-                            for _constraint in solver.constraint.values()
-                        ),
+                        expr_dicts,
                         input_dicts,
                         solver.model,
                         solver.constraint,

--- a/ppsci/solver/train.py
+++ b/ppsci/solver/train.py
@@ -36,9 +36,6 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
     """
     batch_tic = time.perf_counter()
 
-    expr_dicts = tuple(
-        _constraint.output_expr for _constraint in solver.constraint.values()
-    )
     for iter_id in range(1, solver.iters_per_epoch + 1):
         total_loss = 0
         loss_dict = misc.Prettydefaultdict(float)
@@ -78,7 +75,10 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
             # forward for every constraint, including model and equation expression
             with solver.autocast_context_manager(solver.use_amp, solver.amp_level):
                 constraint_losses = solver.forward_helper.train_forward(
-                    expr_dicts,
+                    tuple(
+                        _constraint.output_expr
+                        for _constraint in solver.constraint.values()
+                    ),
                     input_dicts,
                     solver.model,
                     solver.constraint,
@@ -144,9 +144,6 @@ def train_LBFGS_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int
     """
     batch_tic = time.perf_counter()
 
-    expr_dicts = tuple(
-        _constraint.output_expr for _constraint in solver.constraint.values()
-    )
     for iter_id in range(1, solver.iters_per_epoch + 1):
         loss_dict = misc.Prettydefaultdict(float)
         loss_dict["loss"] = 0.0
@@ -186,7 +183,10 @@ def train_LBFGS_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int
                 with solver.autocast_context_manager(solver.use_amp, solver.amp_level):
                     # forward for every constraint, including model and equation expression
                     constraint_losses = solver.forward_helper.train_forward(
-                        expr_dicts,
+                        tuple(
+                            _constraint.output_expr
+                            for _constraint in solver.constraint.values()
+                        ),
                         input_dicts,
                         solver.model,
                         solver.constraint,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 修复 `train.py` 中 `expr_dicts` 生成时未从generator转成tuple，导致 to_static 跟踪的函数签名发生变化而一直处于动转静过程

