### PR TITLE
[Fix] Fix IterableNamedArrayDataset when weight is None

### DIFF
--- a/ppsci/data/dataset/array_dataset.py
+++ b/ppsci/data/dataset/array_dataset.py
@@ -78,7 +78,7 @@ class IterableNamedArrayDataset(io.IterableDataset):
     Args:
         input (Dict[str, np.ndarray]): Input dict.
         label (Dict[str, np.ndarray]): Label dict.
-        weight (Dict[str, np.ndarray]): Weight dict.
+        weight (Optional[Dict[str, np.ndarray]]): Weight dict. Defaults to None.
         transforms (Optional[vision.Compose]): Compose object contains sample wise
             transform(s). Defaults to None.
 
@@ -94,13 +94,17 @@ class IterableNamedArrayDataset(io.IterableDataset):
         self,
         input: Dict[str, np.ndarray],
         label: Dict[str, np.ndarray],
-        weight: Dict[str, np.ndarray],
+        weight: Optional[Dict[str, np.ndarray]] = None,
         transforms: Optional[vision.Compose] = None,
     ):
         super().__init__()
         self.input = {key: paddle.to_tensor(value) for key, value in input.items()}
         self.label = {key: paddle.to_tensor(value) for key, value in label.items()}
-        self.weight = {key: paddle.to_tensor(value) for key, value in weight.items()}
+        self.weight = (
+            {key: paddle.to_tensor(value) for key, value in weight.items()}
+            if weight is not None
+            else None
+        )
         self._len = len(next(iter(self.input.values())))
         self.transforms = transforms
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
主要修改点：
1. 允许 `IterableNamedArrayDataset` 初始化时参数 weight 为 None