### PR TITLE
[Fix] Refine shock wave document; remove redundant warning of geometry_nd.py

### DIFF
--- a/docs/zh/examples/shock_wave.md
+++ b/docs/zh/examples/shock_wave.md
@@ -16,28 +16,29 @@ PINN-WE 模型通过损失函数加权，在 PINN 优化过程中减弱强梯度
 
 $$
 \begin{array}{cc}
-\dfrac{\partial \hat{U}}{\partial t}+\dfrac{\partial \hat{F}}{\partial \xi}+\dfrac{\partial \hat{G}}{\partial \eta}=0 \\
-\text { 其中, } \quad\left\{\begin{array}{l}
-\hat{U}=J U \\
-\hat{F}=J\left(F \xi_x+G \xi_y\right) \\
-\hat{G}=J\left(F \eta_x+G \eta_y\right)
-\end{array}\right. \\
-U=\left(\begin{array}{l}
-\rho \\
-\rho u \\
-\rho v \\
-\rho E
-\end{array}\right), \quad F=\left(\begin{array}{l}
-\rho u \\
-\rho u^2+p \\
-\rho u v \\
-(\rho E+p) u
-\end{array}\right), \quad G=\left(\begin{array}{l}
-\rho v \\
-\rho v u \\
-\rho v^2+p \\
-(\rho E+p) v
-\end{array}\right)
+  \dfrac{\partial \hat{U}}{\partial t}+\dfrac{\partial \hat{F}}{\partial \xi}+\dfrac{\partial \hat{G}}{\partial \eta}=0 \\
+  \text { 其中, } \quad
+  \begin{cases}
+    \hat{U}=J U \\
+    \hat{F}=J\left(F \xi_x+G \xi_y\right) \\
+    \hat{G}=J\left(F \eta_x+G \eta_y\right)
+  \end{cases} \\
+  U=\left(\begin{array}{l}
+  \rho \\
+  \rho u \\
+  \rho v \\
+  E
+  \end{array}\right), \quad F=\left(\begin{array}{l}
+  \rho u \\
+  \rho u^2+p \\
+  \rho u v \\
+  (E+p) u
+  \end{array}\right), \quad G=\left(\begin{array}{l}
+  \rho v \\
+  \rho v u \\
+  \rho v^2+p \\
+  (E+p) v
+  \end{array}\right)
 \end{array}
 $$
 

--- a/ppsci/geometry/geometry_nd.py
+++ b/ppsci/geometry/geometry_nd.py
@@ -76,10 +76,6 @@ class Hypercube(geometry.Geometry):
         # For vertices, the normal is averaged for all directions
         idx = np.count_nonzero(_n, axis=-1) > 1
         if np.any(idx):
-            print(
-                f"Warning: {self.__class__.__name__} boundary_normal called on vertices. "
-                "You may use PDE(..., exclusions=...) to exclude the vertices."
-            )
             l = np.linalg.norm(_n[idx], axis=-1, keepdims=True)
             _n[idx] /= l
         return _n


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs 
### Describe
<!-- Describe what this PR does -->
1. 修正 shockwave 文档公式，去掉 $\rho$
2. 去除 `geometry_nd.py` 中的警告