### PR TITLE
[Fix] remove redundant eval call in solver.train

### DIFF
--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -459,7 +459,6 @@ class Solver:
                 and epoch_id % self.eval_freq == 0
                 and epoch_id >= self.start_eval_epoch
             ):
-                cur_metric = self.eval(epoch_id)
                 cur_metric, metric_dict = self.eval(epoch_id)
                 if cur_metric < self.best_metric["metric"]:
                     self.best_metric["metric"] = cur_metric


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 删除多余的 self.eval 语句