### PR TITLE
[Fix] fix type in _eval_by_dataset

### DIFF
--- a/ppsci/solver/eval.py
+++ b/ppsci/solver/eval.py
@@ -137,7 +137,9 @@ def _eval_by_dataset(
         metric_dict_group: Dict[str, Dict[str, float]] = misc.PrettyOrderedDict()
         for metric_name, metric_func in _validator.metric.items():
             metric_dict = metric_func(all_output, all_label)
-            metric_dict_group[metric_name] = metric_dict
+            metric_dict_group[metric_name] = {
+                k: float(v) for k, v in metric_dict.items()
+            }
             for var_name, metric_value in metric_dict.items():
                 metric_str = f"{metric_name}.{var_name}({_validator.name})"
                 if metric_str not in solver.eval_output_info:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
修复 eval.py _eval_by_dataset 中未将指标转为float导致返回的指标为inf的BUG