### PR TITLE
[Fix] fix hydra using hydra.job.config.override_dirname.exclude_keys

### DIFF
--- a/docs/zh/examples/bracket.md
+++ b/docs/zh/examples/bracket.md
@@ -28,7 +28,7 @@
 
 | 预训练模型  | 指标 |
 |:--| :--|
-| [bracket_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/bracket/bracket_pretrained.pdparams) | loss(commercial_ref_u_v_w_sigmas): 32.28704, MSE.u(commercial_ref_u_v_w_sigmas): 0.00005, MSE.v(commercial_ref_u_v_w_sigmas): 0.00000, MSE.w(commercial_ref_u_v_w_sigmas): 0.00734, MSE.sigma_xx(commercial_ref_u_v_w_sigmas): 27.64751, MSE.sigma_yy(commercial_ref_u_v_w_sigmas): 1.23101, MSE.sigma_zz(commercial_ref_u_v_w_sigmas): 0.89106, MSE.sigma_xy(commercial_ref_u_v_w_sigmas): 0.84370, MSE.sigma_xz(commercial_ref_u_v_w_sigmas): 1.42126, MSE.sigma_yz(commercial_ref_u_v_w_sigmas): 0.24510 |
+| [bracket_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/bracket/bracket_pretrained.pdparams) | loss(commercial_ref_u_v_w_sigmas): 32.28704<br>MSE.u(commercial_ref_u_v_w_sigmas): 0.00005<br>MSE.v(commercial_ref_u_v_w_sigmas): 0.00000<br>MSE.w(commercial_ref_u_v_w_sigmas): 0.00734<br>MSE.sigma_xx(commercial_ref_u_v_w_sigmas): 27.64751<br>MSE.sigma_yy(commercial_ref_u_v_w_sigmas): 1.23101<br>MSE.sigma_zz(commercial_ref_u_v_w_sigmas): 0.89106<br>MSE.sigma_xy(commercial_ref_u_v_w_sigmas): 0.84370<br>MSE.sigma_xz(commercial_ref_u_v_w_sigmas): 1.42126<br>MSE.sigma_yz(commercial_ref_u_v_w_sigmas): 0.24510 |
 
 ## 1. 背景简介
 

--- a/docs/zh/examples/bracket.md
+++ b/docs/zh/examples/bracket.md
@@ -213,11 +213,11 @@ examples/bracket/bracket.py:201:208
 
 ### 3.5 超参数设定
 
-接下来需要在配置文件中指定训练轮数，此处按实验经验，使用 2000 轮训练轮数。
+接下来需要在配置文件中指定训练轮数，此处按实验经验，使用 2000 轮训练轮数，每轮进行 1000 步优化。
 
 ``` py linenums="62"
 --8<--
-examples/bracket/conf/bracket.yaml:62:65
+examples/bracket/conf/bracket.yaml:71:74
 --8<--
 ```
 

--- a/examples/bracket/conf/bracket.yaml
+++ b/examples/bracket/conf/bracket.yaml
@@ -5,6 +5,15 @@ hydra:
   job:
     name: ${mode} # name of logfile
     chdir: false # keep current working direcotry unchaned
+    config:
+      override_dirname:
+        exclude_keys:
+          - TRAIN.checkpoint_path
+          - TRAIN.pretrained_model_path
+          - EVAL.pretrained_model_path
+          - mode
+          - output_dir
+          - log_freq
   sweep:
     # output directory for multirun
     dir: ${hydra.run.dir}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
1. 通过黑名单的方式修复 hydra 配置文件运行时通过命令行指定的参数含有`/`可能导致创建多级目录的BUG
