### PR TITLE
[Fix] Convert order from SympyNumber to python built-in number in symbolic

### DIFF
--- a/docs/zh/development.md
+++ b/docs/zh/development.md
@@ -547,7 +547,7 @@ eta_mse_validator = ppsci.validate.SupervisedValidator(
     ]
     ```
 
-完成上述新评估器代码编写的工作之后，我们就能像 PaddleScience 内置评估器一样，以 `ppsci.equation.NewValidator` 的方式，调用我们编写的新评估器类，并用于创建评估器实例。同样地，在评估器构建完毕后之后，建议将所有评估器包装到一个字典中方便后续索引。
+完成上述新评估器代码编写的工作之后，我们就能像 PaddleScience 内置评估器一样，以 `ppsci.validate.NewValidator` 的方式，调用我们编写的新评估器类，并用于创建评估器实例。同样地，在评估器构建完毕后之后，建议将所有评估器包装到一个字典中方便后续索引。
 
 ``` py title="examples/demo/demo.py"
 new_validator = ppsci.validate.NewValidator(...)

--- a/ppsci/utils/symbolic.py
+++ b/ppsci/utils/symbolic.py
@@ -189,7 +189,7 @@ class OperatorNode(Node):
         # which can reduce considerable overhead of time for calling "_cvt_to_key"
         if self.expr.func == sp.Derivative:
             self.childs = [_cvt_to_key(self.expr.args[0])] + [
-                (_cvt_to_key(arg), order) for (arg, order) in self.expr.args[1:]
+                (_cvt_to_key(arg), int(order)) for (arg, order) in self.expr.args[1:]
             ]
         else:
             self.childs = [_cvt_to_key(arg) for arg in self.expr.args]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1. 修复符号化计算时微分阶数为 `SympyNumber` 而非 Python built-in int 的问题
2. 修复开发文档里的 `NewValidator` 的调用方式错误