### PR TITLE
[Enhance] add retain_graph/create_graph options for jacobian and hessian

### DIFF
--- a/examples/bubble/bubble.py
+++ b/examples/bubble/bubble.py
@@ -298,8 +298,8 @@ def evaluate(cfg: DictConfig):
         psi_y = out["psi"]
         y = in_["y"]
         x = in_["x"]
-        u = jacobian(psi_y, y)
-        v = -jacobian(psi_y, x)
+        u = jacobian(psi_y, y, create_graph=False)
+        v = -jacobian(psi_y, x, create_graph=False)
         return {"u": u, "v": v}
 
     # register transform


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 为 `ppsci.autodiff.jacobian/hessian` 添加 `retain_graph/create_graph` 两个选项，可将 `create_graph` 设置为 `False` 以显著减少推理含有微分操作场景下的显存占用（推理时不需要进行梯度反传，因此 grad 操作不需要创建反向图，从而减少不必要的变量创建）。