### PR TITLE
Bugfix nosampler

### DIFF
--- a/ppsci/data/__init__.py
+++ b/ppsci/data/__init__.py
@@ -82,10 +82,11 @@ def build_dataloader(_dataset, cfg):
         sampler = getattr(io, sampler_cls)(_dataset, **sampler_cfg)
     else:
         if cfg["batch_size"] != 1:
-            raise ValueError(f"`batch_size` should be 1 when sampler config is None, but got 
-        {cfg['batch_size']}")
+            raise ValueError(
+                f"`batch_size` should be 1 when sampler config is None, but got {cfg['batch_size']}."
+            )
         logger.warning(
-            f"`batch_size` is set to 1 as neither sampler config or batch_size is set."
+            "`batch_size` is set to 1 as neither sampler config or batch_size is set."
         )
         sampler = None
 

--- a/ppsci/data/__init__.py
+++ b/ppsci/data/__init__.py
@@ -67,6 +67,7 @@ def build_dataloader(_dataset, cfg):
     cfg = copy.deepcopy(cfg)
 
     # build sampler
+    print("build sampler")
     sampler_cfg = cfg.pop("sampler", None)
     if sampler_cfg is not None:
         sampler_cls = sampler_cfg.pop("name")
@@ -81,6 +82,13 @@ def build_dataloader(_dataset, cfg):
         sampler_cfg["batch_size"] = cfg["batch_size"]
         sampler = getattr(io, sampler_cls)(_dataset, **sampler_cfg)
     else:
+        batch_size = cfg["batch_size"]
+        if batch_size != 1:
+            raise ValueError(f"batch_size : {batch_size} != 1")
+        logger.warning(
+                    f"No sampler specified, it means : input['x'] = NamedArrayDataset.__getitem__(i), batch_size = 1"
+                    f"More information can be found in [https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/DataLoader_cn.html]"
+                )
         sampler = None
 
     # build collate_fn if specified

--- a/ppsci/data/__init__.py
+++ b/ppsci/data/__init__.py
@@ -81,13 +81,12 @@ def build_dataloader(_dataset, cfg):
         sampler_cfg["batch_size"] = cfg["batch_size"]
         sampler = getattr(io, sampler_cls)(_dataset, **sampler_cfg)
     else:
-        batch_size = cfg["batch_size"]
-        if batch_size != 1:
-            raise ValueError(f"batch_size : {batch_size} != 1")
+        if cfg["batch_size"] != 1:
+            raise ValueError(f"`batch_size` should be 1 when sampler config is None, but got 
+        {cfg['batch_size']}")
         logger.warning(
-                    f"No sampler specified, it means : input['x'] = NamedArrayDataset.__getitem__(i), batch_size = 1"
-                    f"More information can be found in [https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/DataLoader_cn.html]"
-                )
+            f"`batch_size` is set to 1 as neither sampler config or batch_size is set."
+        )
         sampler = None
 
     # build collate_fn if specified

--- a/ppsci/data/__init__.py
+++ b/ppsci/data/__init__.py
@@ -67,7 +67,6 @@ def build_dataloader(_dataset, cfg):
     cfg = copy.deepcopy(cfg)
 
     # build sampler
-    print("build sampler")
     sampler_cfg = cfg.pop("sampler", None)
     if sampler_cfg is not None:
         sampler_cls = sampler_cfg.pop("name")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
When setting a data-loader config without a sampler:
```
# set data-loader config
train_dataloader_cfg = {
    "dataset": {
        "name": "NamedArrayDataset",
        "input":input_train,
        "label":label_train
    },
    "batch_size": Nb_train,
    'iters_per_epoch':ITERS_PER_EPOCH,
    # "sampler": {
    #     "name": "BatchSampler",
    #     "drop_last": False,
    #     "shuffle": True,
    # },
}
```
Logics in `def build_dataloader(_dataset, cfg):` will triger `sampler=None`. This leads to no processing being performed on the input data（No batch is composed， naked __getitem(0)).

Then a raise or warning is necessary. NS