### PR TITLE
[Fix] use Assign with fp64 in XPINNs

### DIFF
--- a/jointContribution/XPINNs/XPINN_2D_PoissonsEqn.py
+++ b/jointContribution/XPINNs/XPINN_2D_PoissonsEqn.py
@@ -9,6 +9,7 @@ import scipy.io
 from matplotlib import gridspec
 from matplotlib import patches
 from matplotlib import tri
+from paddle import nn
 
 import ppsci
 
@@ -19,7 +20,7 @@ np.random.seed(1234)
 paddle.seed(1234)
 
 
-class XPINN(paddle.nn.Layer):
+class XPINN(nn.Layer):
     # Initialize the class
     def __init__(self, layer_list):
         super().__init__()
@@ -130,13 +131,13 @@ class XPINN(paddle.nn.Layer):
                 shape=[1, layers[l + 1]],
                 dtype="float64",
                 is_bias=True,
-                default_initializer=paddle.nn.initializer.Constant(0.0),
+                default_initializer=nn.initializer.Constant(0.0),
             )
             amplitude = self.create_parameter(
                 shape=[1],
                 dtype="float64",
                 is_bias=True,
-                default_initializer=paddle.nn.initializer.Constant(0.05),
+                default_initializer=nn.initializer.Constant(0.05),
             )
 
             self.add_parameter(name_prefix + "_w_" + str(l), weight)
@@ -153,8 +154,7 @@ class XPINN(paddle.nn.Layer):
         xavier_stddev = np.sqrt(2 / (in_dim + out_dim))
         param = paddle.empty(size, "float64")
         param = ppsci.utils.initializer.trunc_normal_(param, 0.0, xavier_stddev)
-        # TODO: Truncated normal and assign support float64
-        return lambda p_ten, _: p_ten.set_value(param)
+        return nn.initializer.Assign(param)
 
     def neural_net_tanh(self, x, weights, biases, amplitudes):
         num_layers = len(weights) + 1
@@ -479,8 +479,7 @@ if __name__ == "__main__":
     print("Error u_total: %e" % (error_u_total))
 
     ############################# Plotting ###############################
-    if not os.path.exists("./target"):
-        os.mkdir("./target")
+    os.makedirs("./target", exist_ok=True)
     fig, ax = plotting.newfig(1.0, 1.1)
     plt.plot(range(1, max_iter + 1, 20), mse_hist1, "r-", linewidth=1, label="Sub-Net1")
     plt.plot(

--- a/ppsci/optimizer/lr_scheduler.py
+++ b/ppsci/optimizer/lr_scheduler.py
@@ -150,7 +150,7 @@ class Linear(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.Linear(10, 2, 0.001)
+        >>> lr = ppsci.optimizer.lr_scheduler.Linear(10, 2, 0.001)()
     """
 
     def __init__(
@@ -218,7 +218,7 @@ class ExponentialDecay(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.ExponentialDecay(10, 2, 1e-3, 0.95, 3)
+        >>> lr = ppsci.optimizer.lr_scheduler.ExponentialDecay(10, 2, 1e-3, 0.95, 3)()
     """
 
     def __init__(
@@ -280,7 +280,7 @@ class Cosine(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.Cosine(10, 2, 1e-3)
+        >>> lr = ppsci.optimizer.lr_scheduler.Cosine(10, 2, 1e-3)()
     """
 
     def __init__(
@@ -345,7 +345,7 @@ class Step(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.Step(10, 1, 1e-3, 2, 0.95)
+        >>> lr = ppsci.optimizer.lr_scheduler.Step(10, 1, 1e-3, 2, 0.95)()
     """
 
     def __init__(
@@ -407,7 +407,9 @@ class Piecewise(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.Piecewise(10, 1, [2, 4], (1e-3, 1e-4))
+        >>> lr = ppsci.optimizer.lr_scheduler.Piecewise(
+        ...     10, 1, [2, 4], (1e-3, 1e-4, 1e-5)
+        ... )()
     """
 
     def __init__(
@@ -467,7 +469,7 @@ class MultiStepDecay(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.MultiStepDecay(10, 1, 1e-3, (4, 5))
+        >>> lr = ppsci.optimizer.lr_scheduler.MultiStepDecay(10, 1, 1e-3, (4, 5))()
     """
 
     def __init__(
@@ -601,7 +603,7 @@ class CosineWarmRestarts(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.CosineWarmRestarts(20, 1, 1e-3, 14, 2)
+        >>> lr = ppsci.optimizer.lr_scheduler.CosineWarmRestarts(20, 1, 1e-3, 14, 2)()
     """
 
     def __init__(
@@ -676,7 +678,7 @@ class OneCycleLR(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.OneCycleLR(1e-3, 100)
+        >>> lr = ppsci.optimizer.lr_scheduler.OneCycleLR(100, 1, 1e-3)()
     """
 
     def __init__(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
1. 基于 PaddlePaddle/Paddle#57507，在 XPINNs 案例中使用支持 float64 的 `Assign` API 代替原有复杂写法
2. 修复 `lr_scheduler` 模块中不正确的 Example 代码