### PR TITLE
[Doc] Add pretrained model for cylinder2d_unsteady_Re100, darcy2d and fix filename

### DIFF
--- a/docs/zh/examples/cylinder2d_unsteady.md
+++ b/docs/zh/examples/cylinder2d_unsteady.md
@@ -23,12 +23,12 @@
     # curl https://paddle-org.bj.bcebos.com/paddlescience/datasets/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_dataset.tar --output cylinder2d_unsteady_Re100_dataset.tar
     # unzip it
     tar -xvf cylinder2d_unsteady_Re100_dataset.tar
-    python cylinder2d_unsteady_Re100.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_pretrain.pdparams
+    python cylinder2d_unsteady_Re100.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_pretrained.pdparams
     ```
 
 | 预训练模型  | 指标 |
 |:--| :--|
-| [cylinder2d_unsteady_Re100_pretrain.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_pretrain.pdparams) | loss(Residual): 0.00398<br>MSE.continuity(Residual): 0.00126<br>MSE.momentum_x(Residual): 0.00151<br>MSE.momentum_y(Residual): 0.00120 |
+| [cylinder2d_unsteady_Re100_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_pretrained.pdparams) | loss(Residual): 0.00398<br>MSE.continuity(Residual): 0.00126<br>MSE.momentum_x(Residual): 0.00151<br>MSE.momentum_y(Residual): 0.00120 |
 
 ## 1. 背景简介
 

--- a/docs/zh/examples/cylinder2d_unsteady.md
+++ b/docs/zh/examples/cylinder2d_unsteady.md
@@ -14,6 +14,22 @@
     python cylinder2d_unsteady_Re100.py
     ```
 
+=== "模型评估命令"
+
+    ``` sh
+    # linux
+    wget https://paddle-org.bj.bcebos.com/paddlescience/datasets/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_dataset.tar
+    # windows
+    # curl https://paddle-org.bj.bcebos.com/paddlescience/datasets/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_dataset.tar --output cylinder2d_unsteady_Re100_dataset.tar
+    # unzip it
+    tar -xvf cylinder2d_unsteady_Re100_dataset.tar
+    python cylinder2d_unsteady_Re100.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_pretrain.pdparams
+    ```
+
+| 预训练模型  | 指标 |
+|:--| :--|
+| [cylinder2d_unsteady_Re100_pretrain.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/cylinder2d_unsteady_Re100/cylinder2d_unsteady_Re100_pretrain.pdparams) | loss(Residual): 0.00398<br>MSE.continuity(Residual): 0.00126<br>MSE.momentum_x(Residual): 0.00151<br>MSE.momentum_y(Residual): 0.00120 |
+
 ## 1. 背景简介
 
 圆柱绕流问题可以应用于很多领域。例如，在工业设计中，它可以被用来模拟和优化流体在各种设备中的流动，如风力发电机、汽车和飞机的流体动力学性能等。在环保领域，圆柱绕流问题也有应用，如预测和控制河流的洪水、研究污染物的扩散等。此外，在工程实践中，如流体动力学、流体静力学、热交换、空气动力学等领域，圆柱绕流问题也具有实际意义。

--- a/docs/zh/examples/darcy2d.md
+++ b/docs/zh/examples/darcy2d.md
@@ -14,6 +14,11 @@
     python darcy2d.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/darcy2d/darcy2d_pretrained.pdparams
     ```
 
+| 预训练模型  | 指标 |
+|:--| :--|
+| [darcy2d_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/darcy2d/darcy2d_pretrained.pdparams) | loss(Residual): 0.36500<br>MSE.poisson(Residual): 0.00006 |
+
+
 ## 1. 背景简介
 
 Darcy Flow是一个基于达西定律的工具，用于计算液体的流动。在地下水模拟、水文学、水文地质学和石油工程等领域中，Darcy Flow被广泛应用。

--- a/docs/zh/examples/ldc2d_steady.md
+++ b/docs/zh/examples/ldc2d_steady.md
@@ -11,8 +11,12 @@
 === "模型评估命令"
 
     ``` sh
-    python ldc2d_steady_Re10.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_steady_Re10/output_ldc2d_steady_Re10_pretrain.pdparams
+    python ldc2d_steady_Re10.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_steady_Re10/ldc2d_steady_Re10_pretrain.pdparams
     ```
+
+| 预训练模型  | 指标 |
+|:--| :--|
+| [ldc2d_steady_Re10_pretrain.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_steady_Re10/ldc2d_steady_Re10_pretrain.pdparams) | loss(Residual): 365.36164<br>MSE.momentum_x(Residual): 0.01435<br>MSE.continuity(Residual): 0.04072<br>MSE.momentum_y(Residual): 0.02471 |
 
 ## 1. 背景简介
 

--- a/docs/zh/examples/ldc2d_steady.md
+++ b/docs/zh/examples/ldc2d_steady.md
@@ -11,12 +11,12 @@
 === "模型评估命令"
 
     ``` sh
-    python ldc2d_steady_Re10.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_steady_Re10/ldc2d_steady_Re10_pretrain.pdparams
+    python ldc2d_steady_Re10.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_steady_Re10/ldc2d_steady_Re10_pretrained.pdparams
     ```
 
 | 预训练模型  | 指标 |
 |:--| :--|
-| [ldc2d_steady_Re10_pretrain.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_steady_Re10/ldc2d_steady_Re10_pretrain.pdparams) | loss(Residual): 365.36164<br>MSE.momentum_x(Residual): 0.01435<br>MSE.continuity(Residual): 0.04072<br>MSE.momentum_y(Residual): 0.02471 |
+| [ldc2d_steady_Re10_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_steady_Re10/ldc2d_steady_Re10_pretrained.pdparams) | loss(Residual): 365.36164<br>MSE.momentum_x(Residual): 0.01435<br>MSE.continuity(Residual): 0.04072<br>MSE.momentum_y(Residual): 0.02471 |
 
 ## 1. 背景简介
 

--- a/docs/zh/examples/ldc2d_unsteady.md
+++ b/docs/zh/examples/ldc2d_unsteady.md
@@ -11,8 +11,12 @@
 === "模型评估命令"
 
     ``` sh
-    python ldc2d_unsteady_Re10.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_unsteady_Re10/output_ldc2d_unsteady_Re10_pretrain.pdparams
+    python ldc2d_unsteady_Re10.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_unsteady_Re10/ldc2d_unsteady_Re10_pretrain.pdparams
     ```
+
+| 预训练模型  | 指标 |
+|:--| :--|
+| [ldc2d_unsteady_Re10_pretrain.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_unsteady_Re10/ldc2d_unsteady_Re10_pretrain.pdparams) | loss(Residual): 155652.67530<br>MSE.momentum_x(Residual): 6.78030<br>MSE.continuity(Residual): 0.16590<br>MSE.momentum_y(Residual): 12.05981 |
 
 ## 1. 背景简介
 

--- a/docs/zh/examples/ldc2d_unsteady.md
+++ b/docs/zh/examples/ldc2d_unsteady.md
@@ -11,12 +11,12 @@
 === "模型评估命令"
 
     ``` sh
-    python ldc2d_unsteady_Re10.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_unsteady_Re10/ldc2d_unsteady_Re10_pretrain.pdparams
+    python ldc2d_unsteady_Re10.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_unsteady_Re10/ldc2d_unsteady_Re10_pretrained.pdparams
     ```
 
 | 预训练模型  | 指标 |
 |:--| :--|
-| [ldc2d_unsteady_Re10_pretrain.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_unsteady_Re10/ldc2d_unsteady_Re10_pretrain.pdparams) | loss(Residual): 155652.67530<br>MSE.momentum_x(Residual): 6.78030<br>MSE.continuity(Residual): 0.16590<br>MSE.momentum_y(Residual): 12.05981 |
+| [ldc2d_unsteady_Re10_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/ldc2d_unsteady_Re10/ldc2d_unsteady_Re10_pretrained.pdparams) | loss(Residual): 155652.67530<br>MSE.momentum_x(Residual): 6.78030<br>MSE.continuity(Residual): 0.16590<br>MSE.momentum_y(Residual): 12.05981 |
 
 ## 1. 背景简介
 

--- a/docs/zh/user_guide.md
+++ b/docs/zh/user_guide.md
@@ -179,7 +179,7 @@ PaddleScience/examples/bracket/outputs_bracket/
     # 用该模型及其对应的预训练模型路径(或下载地址 url)两个参数初始化 solver
     solver = ppsci.solver.Solver(
         model=model,
-        pretrained_model_path="/path/to/pretrain.pdparams",
+        pretrained_model_path="/path/to/pretrained.pdparams",
     )
     # 在 Solver(...) 中会自动从给定的 pretrained_model_path 加载(下载)参数并赋值给 model 的对应参数
     ```


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs 
### Describe
<!-- Describe what this PR does -->
1. 添加 cylinder2d_unsteady_Re100、darcy2d 的预训练模型、评估命令和评估指标
2. 修正预训练模型的名字，`xxx_pretrain.pdparams` --> `xxx_pretrained.pdparams`