### PR TITLE
【benchmark】add max_mem_reserved for benchmark 

### DIFF
--- a/ppsci/solver/printer.py
+++ b/ppsci/solver/printer.py
@@ -25,6 +25,7 @@ from ppsci.utils import misc
 
 if TYPE_CHECKING:
     from ppsci import solver
+import paddle
 
 
 def update_train_loss(
@@ -72,10 +73,12 @@ def log_train_info(
         (trainer.epochs - epoch_id + 1) * trainer.iters_per_epoch - iter_id
     ) * trainer.train_time_info["batch_cost"].avg
     eta_msg = f"eta: {str(datetime.timedelta(seconds=int(eta_sec))):s}"
+    max_mem_reserved_msg = f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved()} B"
+    max_mem_allocated_msg = f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated()} B"
     logger.info(
         f"[Train][Epoch {epoch_id}/{trainer.epochs}]"
         f"[Iter: {iter_id}/{trainer.iters_per_epoch}] {lr_msg}, "
-        f"{metric_msg}, {time_msg}, {ips_msg}, {eta_msg}"
+        f"{metric_msg}, {time_msg}, {ips_msg}, {eta_msg}, {max_mem_reserved_msg}, {max_mem_allocated_msg}"
     )
 
     logger.scaler(

--- a/ppsci/solver/printer.py
+++ b/ppsci/solver/printer.py
@@ -73,8 +73,12 @@ def log_train_info(
         (trainer.epochs - epoch_id + 1) * trainer.iters_per_epoch - iter_id
     ) * trainer.train_time_info["batch_cost"].avg
     eta_msg = f"eta: {str(datetime.timedelta(seconds=int(eta_sec))):s}"
-    max_mem_reserved_msg = f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved()} B"
-    max_mem_allocated_msg = f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated()} B"
+    max_mem_reserved_msg = (
+        f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved()} B"
+    )
+    max_mem_allocated_msg = (
+        f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated()} B"
+    )
     logger.info(
         f"[Train][Epoch {epoch_id}/{trainer.epochs}]"
         f"[Iter: {iter_id}/{trainer.iters_per_epoch}] {lr_msg}, "


### PR DESCRIPTION
### PR types
 Others 

### PR changes
 Others 

### Describe
训练benchmark 使用 API paddle.device.cuda.max_memory_reserved() 收集模型训练时的显存占用，因此本PR 修改 benchmark 打印日志部分，新增 max_mem_reserved max_mem_allocated 指标打印；如下：

[2023/11/21 14:46:46] ppsci INFO: [Train][Epoch 2884/10000][Iter: 1/1] lr: 0.00100, loss: 0.00005, EQ: 0.00005, BC: 0.00000, batch_cost: 0.02397s, reader_cost: 0.00001s, ips: 4338.87669 samples/s, eta: 0:02:50, max_mem_reserved: 1265408 B, max_mem_allocated: 1255424 B