### PR TITLE
[Fix] Fix for all_gather is not supported by CUDAPinnedPlace and PIRBN

### DIFF
--- a/docs/zh/examples/phylstm.md
+++ b/docs/zh/examples/phylstm.md
@@ -49,21 +49,6 @@
 | [phylstm2_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm2_pretrained.pdparams) | loss(sup_valid): 0.00799 |
 | [phylstm3_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm3_pretrained.pdparams) | loss(sup_valid): 0.03098 |
 
-    === phylstm3
-
-    ``` sh
-    # linux
-    wget https://paddle-org.bj.bcebos.com/paddlescience/datasets/PhyLSTM/data_boucwen.mat
-    # windows
-    # curl https://paddle-org.bj.bcebos.com/paddlescience/datasets/PhyLSTM/data_boucwen.mat --output data_boucwen.mat
-    python phylstm3.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm3_pretrained.pdparams
-    ```
-
-| 预训练模型  | 指标 |
-|:--| :--|
-| [phylstm2_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm2_pretrained.pdparams) | loss(sup_valid): 0.00799 |
-| [phylstm3_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm3_pretrained.pdparams) | loss(sup_valid): 0.03098 |
-
 ## 1. 背景简介
 
 我们引入了一种创新的物理知识LSTM框架，用于对缺乏数据的非线性结构系统进行元建模。基本概念是将可用但尚不完整的物理知识（如物理定律、科学原理）整合到深度长短时记忆（LSTM）网络中，该网络在可行的解决方案空间内限制和促进学习。物理约束嵌入在损失函数中，以强制执行模型训练，即使在可用训练数据集非常有限的情况下，也能准确地捕捉潜在的系统非线性。特别是对于动态结构，考虑运动方程的物理定律、状态依赖性和滞后本构关系来构建物理损失。嵌入式物理可以缓解过拟合问题，减少对大型训练数据集的需求，并提高训练模型的鲁棒性，使其具有外推能力，从而进行更可靠的预测。因此，物理知识指导的深度学习范式优于传统的非物理指导的数据驱动神经网络。

--- a/jointContribution/PIRBN/jacobian_function.py
+++ b/jointContribution/PIRBN/jacobian_function.py
@@ -22,11 +22,11 @@ def flat(x, start_axis=0, stop_axis=None):
 def jacobian(y, x):
     J_shape = y.shape + x.shape
     J = paddle.zeros(J_shape)
-    y_flat = flat(y)
     J_flat = flat(
         J, start_axis=0, stop_axis=len(y.shape) - 1
     )  # partialy flatten as y_flat
-    for i, y_i in enumerate(y_flat):
+    for i, y_i in enumerate(y):
+        assert y_i.size == 1, f"y_i.size shoule be 1, but got {y_i.size}"
         grad = paddle.grad(y_i, x, allow_unused=True)[
             0
         ]  # grad[i] == sum by j (dy[j] / dx[i])

--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -286,8 +286,10 @@ class Solver:
                     "before 'Solver.__init__' and keep it's type as 'nn.Layer'."
                 )
             self.model = fleet.distributed_model(self.model)
-            self.model.input_keys = self.model._layers.input_keys
-            self.model.output_keys = self.model._layers.output_keys
+            if hasattr(self.model, "input_keys"):
+                self.model.input_keys = self.model._layers.input_keys
+            if hasattr(self.model, "output_keys"):
+                self.model.output_keys = self.model._layers.output_keys
             if self.optimizer is not None:
                 self.optimizer = fleet.distributed_optimizer(self.optimizer)
 

--- a/ppsci/utils/misc.py
+++ b/ppsci/utils/misc.py
@@ -237,13 +237,19 @@ def all_gather(
         axis (int, optional): Axis which concatenated along. Defaults to 0.
 
     Returns:
-        Union[paddle.Tensor, List[paddle.Tensor]]: Gathered Tensors
+        Union[paddle.Tensor, List[paddle.Tensor]]: Gathered Tensors.
     """
     result: List[paddle.Tensor] = []
+
+    # NOTE: Put tensor to CUDAPlace from CUDAPinnedPlace to use communication.
+    if tensor.place.is_cuda_pinned_place():
+        tensor = tensor.cuda()
+
     # TODO(HydrogenSulfate): As non-contiguous(strided) tensor is not supported in
     # dist.all_gather, manually convert given Tensor to contiguous below. Strided tensor
     # will be supported in future.
     dist.all_gather(result, tensor.contiguous())
+
     if concat:
         return paddle.concat(result, axis)
     return result


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 由于 `CUDAPinnedPlace` 暂时不支持部分分布式通讯API，因此 `misc.all_gather` 时遇到从 dataloader 中直接拿到 `CUDAPinnedPlace` 设备类型的数据时，手动转换到 `CUDAPlace`，避免报错。
2. 修复 PIRBN grad 报错问题