### PR TITLE
[Fix] Remove padding data at the end of solver.predict

### DIFF
--- a/docs/zh/examples/heat_pinn.md
+++ b/docs/zh/examples/heat_pinn.md
@@ -14,7 +14,7 @@
 
 | 预训练模型  | 指标 |
 |:--| :--|
-| [heat_pinn_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/heat_pinn/heat_pinn_pretrained.pdparams) | norm MSE loss between the FDM and PINN is 0.0013415 |
+| [heat_pinn_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/heat_pinn/heat_pinn_pretrained.pdparams) | norm MSE loss between the FDM and PINN is 1.30174e-03 |
 
 ## 1. 背景简介
 

--- a/docs/zh/examples/phylstm.md
+++ b/docs/zh/examples/phylstm.md
@@ -49,21 +49,6 @@
 | [phylstm2_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm2_pretrained.pdparams) | loss(sup_valid): 0.00799 |
 | [phylstm3_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm3_pretrained.pdparams) | loss(sup_valid): 0.03098 |
 
-    === phylstm3
-
-    ``` sh
-    # linux
-    wget https://paddle-org.bj.bcebos.com/paddlescience/datasets/PhyLSTM/data_boucwen.mat
-    # windows
-    # curl https://paddle-org.bj.bcebos.com/paddlescience/datasets/PhyLSTM/data_boucwen.mat --output data_boucwen.mat
-    python phylstm3.py mode=eval EVAL.pretrained_model_path=https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm3_pretrained.pdparams
-    ```
-
-| 预训练模型  | 指标 |
-|:--| :--|
-| [phylstm2_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm2_pretrained.pdparams) | loss(sup_valid): 0.00799 |
-| [phylstm3_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/phylstm/phylstm3_pretrained.pdparams) | loss(sup_valid): 0.03098 |
-
 ## 1. 背景简介
 
 我们引入了一种创新的物理知识LSTM框架，用于对缺乏数据的非线性结构系统进行元建模。基本概念是将可用但尚不完整的物理知识（如物理定律、科学原理）整合到深度长短时记忆（LSTM）网络中，该网络在可行的解决方案空间内限制和促进学习。物理约束嵌入在损失函数中，以强制执行模型训练，即使在可用训练数据集非常有限的情况下，也能准确地捕捉潜在的系统非线性。特别是对于动态结构，考虑运动方程的物理定律、状态依赖性和滞后本构关系来构建物理损失。嵌入式物理可以缓解过拟合问题，减少对大型训练数据集的需求，并提高训练模型的鲁棒性，使其具有外推能力，从而进行更可靠的预测。因此，物理知识指导的深度学习范式优于传统的非物理指导的数据驱动神经网络。

--- a/examples/heat_pinn/heat_pinn.py
+++ b/examples/heat_pinn/heat_pinn.py
@@ -139,8 +139,8 @@ def train(cfg: DictConfig):
         N_EVAL, N_EVAL
     )
     fdm_output = fdm.solve(N_EVAL, 1).T
-    mes_loss = np.mean(np.square(pinn_output - (fdm_output / 75.0)))
-    logger.info(f"The norm MSE loss between the FDM and PINN is {mes_loss}")
+    mse_loss = np.mean(np.square(pinn_output - (fdm_output / 75.0)))
+    logger.info(f"The norm MSE loss between the FDM and PINN is {mse_loss}")
 
     x = input_data["x"].reshape(N_EVAL, N_EVAL)
     y = input_data["y"].reshape(N_EVAL, N_EVAL)
@@ -237,8 +237,8 @@ def evaluate(cfg: DictConfig):
         "u"
     ].reshape(N_EVAL, N_EVAL)
     fdm_output = fdm.solve(N_EVAL, 1).T
-    mes_loss = np.mean(np.square(pinn_output - (fdm_output / 75.0)))
-    logger.info(f"The norm MSE loss between the FDM and PINN is {mes_loss}")
+    mse_loss = np.mean(np.square(pinn_output - (fdm_output / 75.0)))
+    logger.info(f"The norm MSE loss between the FDM and PINN is {mse_loss:.5e}")
 
     x = input_data["x"].reshape(N_EVAL, N_EVAL)
     y = input_data["y"].reshape(N_EVAL, N_EVAL)

--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -234,7 +234,8 @@ class Solver:
             logger.warning(
                 f"Detected 'world_size'({self.world_size}) > 1, it is recommended to "
                 "scale up the learning rate and reduce the 'epochs' or "
-                "'iters_per_epoch' according to the 'world_size' both linearly."
+                "'iters_per_epoch' according to the 'world_size' both linearly if you "
+                "are training model."
             )
 
         # load pretrained model, usually used for transfer learning
@@ -596,6 +597,11 @@ class Solver:
                     pred_dict = {
                         key: value[:num_samples] for key, value in pred_dict.items()
                     }
+                    # NOTE: Discard padding data in input_dict for consistency
+                    for k in input_dict:
+                        print(id(input_dict[k]))
+                        input_dict[k] = input_dict[k][:num_samples]
+                        print(id(input_dict[k]))
 
         # convert to numpy ndarray if specified
         if return_numpy:

--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -512,8 +512,6 @@ class Solver:
         # pad with last element if `num_samples` is not divisible by `world_size`
         # ensuring every device get same number of data.
         if num_pad > 0:
-            # NOTE: This will modify input_dict inplace by appending padding data at the
-            # end if num_pad > 0.
             for k, v in input_dict.items():
                 repeat_times = (num_pad, *(1 for _ in range(v.ndim - 1)))
                 if isinstance(v, np.ndarray):
@@ -599,9 +597,7 @@ class Solver:
                     }
                     # NOTE: Discard padding data in input_dict for consistency
                     for k in input_dict:
-                        print(id(input_dict[k]))
                         input_dict[k] = input_dict[k][:num_samples]
-                        print(id(input_dict[k]))
 
         # convert to numpy ndarray if specified
         if return_numpy:


### PR DESCRIPTION
 <!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
1. 在 `Solver.predict` 返回前，删除在 `input_dict` 末尾 padding 的数据，避免影响输入数据
2. 规范 heat_pinn 案例的精度指标格式，修正代码拼写错误：`mes`-->`mse`