### PR TITLE
[Fea] Add setuptools_scm to manger version of paddlesci

### DIFF
--- a/ppsci/__init__.py
+++ b/ppsci/__init__.py
@@ -31,6 +31,15 @@ from ppsci.utils.checker import run_check  # isort:skip
 from ppsci.utils.checker import run_check_mesh  # isort:skip
 from ppsci.utils import lambdify  # isort:skip
 
+
+try:
+    # import auto-generated version information from '._version' file, using
+    # setuptools_scm via 'pip install'. Details of versioning rule can be referd to:
+    # https://peps.python.org/pep-0440/#public-version-identifiers
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "unknown version"
+
 __all__ = [
     "arch",
     "autodiff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=65"]
+requires = ["setuptools>=65", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "paddlesci"
-version = "1.0.0"
+dynamic = ["version"]
 description = "A library for scientific machine learning"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -69,3 +69,6 @@ exclude = ["docs*", "examples*", "jointContribution*", "test_tipc*", "test*", "t
 line-length = 88
 ignore = ["E501", "E741"]
 extend-exclude = ["./ppsci/geometry/inflation.py", "./ppsci/autodiff/__init__.py"]
+
+[tool.setuptools_scm]
+write_to = "ppsci/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ def get_requirements() -> list:
 if __name__ == "__main__":
     setuptools.setup(
         name="paddlesci",
-        version="1.0.0",
         author="PaddlePaddle",
         url="https://github.com/PaddlePaddle/PaddleScience",
         description=(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
1. 添加 scm 工具，pip 安装时会产生版本信息
    
    ``` diff
    Successfully built paddlesci
    Installing collected packages: paddlesci
      Attempting uninstall: paddlesci
        Found existing installation: paddlesci 1.0.1.dev257+g7bf0c772.d20231205
        Uninstalling paddlesci-1.0.1.dev257+g7bf0c772.d20231205:
    +      Successfully uninstalled paddlesci-1.0.1.dev257+g7bf0c772.d20231205
    + Successfully installed paddlesci-1.0.1.dev257+g7bf0c772.d20231205
    ```