### PR TITLE
[Fix] Remove restrict for version of mkdocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 Jinja2==3.0.3
 matplotlib
-mkdocs==1.4.2
+mkdocs
 mkdocs-autorefs
 mkdocs-git-revision-date-localized-plugin
 mkdocs-glightbox


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs 
### Describe
<!-- Describe what this PR does -->
1. 移除`docs/requirements.txt` 中对 mkdocs 的版本限制，否则只能安装老版本的 mkdocs-material 