### PR TITLE
[Fix] Fix float type from fp64 to fp32 for area and sdf

### DIFF
--- a/ppsci/geometry/mesh.py
+++ b/ppsci/geometry/mesh.py
@@ -159,7 +159,7 @@ class Mesh(geometry.Geometry):
         import pymesh
 
         sdf, _, _, _ = pymesh.signed_distance_to_mesh(self.py_mesh, points)
-        sdf = sdf[..., np.newaxis]
+        sdf = sdf[..., np.newaxis].astype(paddle.get_default_dtype())
         return sdf
 
     def is_inside(self, x):
@@ -478,7 +478,9 @@ class Mesh(geometry.Geometry):
 
         all_points = np.concatenate(all_points, axis=0)
         cuboid_volume = np.prod([b[1] - b[0] for b in self.bounds])
-        all_areas = np.full((n, 1), cuboid_volume * (_nvalid / _nsample) / n)
+        all_areas = np.full(
+            (n, 1), cuboid_volume * (_nvalid / _nsample) / n, paddle.get_default_dtype()
+        )
         return all_points, all_areas
 
     def sample_interior(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 根据 PaddlePaddle/Paddle#59518，修改 sdf 和 area 的数据类型为 paddle 默认类型，否则会触发大量的类型提升至 float64 的警告