### PR TITLE
[Enh] Avoid multiplication with weight 1 if weight is None

### DIFF
--- a/ppsci/constraint/boundary_constraint.py
+++ b/ppsci/constraint/boundary_constraint.py
@@ -131,8 +131,9 @@ class BoundaryConstraint(base.Constraint):
                 raise NotImplementedError(f"type of {type(value)} is invalid yet.")
 
         # prepare weight
-        weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
+        weight = None
         if weight_dict is not None:
+            weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
             for key, value in weight_dict.items():
                 if isinstance(value, (int, float)):
                     weight[key] = np.full_like(next(iter(label.values())), value)

--- a/ppsci/constraint/initial_constraint.py
+++ b/ppsci/constraint/initial_constraint.py
@@ -138,8 +138,9 @@ class InitialConstraint(base.Constraint):
                 raise NotImplementedError(f"type of {type(value)} is invalid yet.")
 
         # prepare weight
-        weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
+        weight = None
         if weight_dict is not None:
+            weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
             for key, value in weight_dict.items():
                 if isinstance(value, (int, float)):
                     weight[key] = np.full_like(next(iter(label.values())), value)

--- a/ppsci/constraint/integral_constraint.py
+++ b/ppsci/constraint/integral_constraint.py
@@ -144,8 +144,9 @@ class IntegralConstraint(base.Constraint):
 
         # prepare weight
         # shape of each weight is [batch_size, ndim]
-        weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
+        weight = None
         if weight_dict is not None:
+            weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
             for key, value in weight_dict.items():
                 if isinstance(value, (int, float)):
                     weight[key] = np.full_like(next(iter(label.values())), value)

--- a/ppsci/constraint/interior_constraint.py
+++ b/ppsci/constraint/interior_constraint.py
@@ -135,8 +135,9 @@ class InteriorConstraint(base.Constraint):
                 raise NotImplementedError(f"type of {type(value)} is invalid yet.")
 
         # prepare weight
-        weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
+        weight = None
         if weight_dict is not None:
+            weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
             for key, value in weight_dict.items():
                 if isinstance(value, str):
                     if value == "sdf":

--- a/ppsci/constraint/periodic_constraint.py
+++ b/ppsci/constraint/periodic_constraint.py
@@ -137,8 +137,9 @@ class PeriodicConstraint(base.Constraint):
             )
 
         # # prepare weight, keep weight the same shape as input_periodic
-        weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
+        weight = None
         if weight_dict is not None:
+            weight = {key: np.ones_like(next(iter(label.values()))) for key in label}
             for key, value in weight_dict.items():
                 if isinstance(value, (int, float)):
                     weight[key] = np.full_like(next(iter(label.values())), value)

--- a/ppsci/data/dataset/csv_dataset.py
+++ b/ppsci/data/dataset/csv_dataset.py
@@ -111,9 +111,11 @@ class CSVDataset(io.Dataset):
         }
 
         # prepare weights
-        self.weight = {
-            key: np.ones_like(next(iter(self.label.values()))) for key in self.label
-        }
+        self.weight = (
+            {key: np.ones_like(next(iter(self.label.values()))) for key in self.label}
+            if weight_dict is not None
+            else {}
+        )
         if weight_dict is not None:
             for key, value in weight_dict.items():
                 if isinstance(value, (int, float)):
@@ -231,9 +233,11 @@ class IterableCSVDataset(io.IterableDataset):
         }
 
         # prepare weights
-        self.weight = {
-            key: np.ones_like(next(iter(self.label.values()))) for key in self.label
-        }
+        self.weight = (
+            {key: np.ones_like(next(iter(self.label.values()))) for key in self.label}
+            if weight_dict is not None
+            else {}
+        )
         if weight_dict is not None:
             for key, value in weight_dict.items():
                 if isinstance(value, (int, float)):

--- a/ppsci/data/dataset/mat_dataset.py
+++ b/ppsci/data/dataset/mat_dataset.py
@@ -111,9 +111,11 @@ class MatDataset(io.Dataset):
         }
 
         # prepare weights
-        self.weight = {
-            key: np.ones_like(next(iter(self.label.values()))) for key in self.label
-        }
+        self.weight = (
+            {key: np.ones_like(next(iter(self.label.values()))) for key in self.label}
+            if weight_dict is not None
+            else {}
+        )
         if weight_dict is not None:
             for key, value in weight_dict.items():
                 if isinstance(value, (int, float)):
@@ -231,9 +233,11 @@ class IterableMatDataset(io.IterableDataset):
         }
 
         # prepare weights
-        self.weight = {
-            key: np.ones_like(next(iter(self.label.values()))) for key in self.label
-        }
+        self.weight = (
+            {key: np.ones_like(next(iter(self.label.values()))) for key in self.label}
+            if weight_dict is not None
+            else {}
+        )
         if weight_dict is not None:
             for key, value in weight_dict.items():
                 if isinstance(value, (int, float)):

--- a/ppsci/loss/integral.py
+++ b/ppsci/loss/integral.py
@@ -85,7 +85,7 @@ class IntegralLoss(base.Loss):
                 label_dict[key],
                 "none",
             )
-            if weight_dict:
+            if weight_dict and key in weight_dict:
                 loss *= weight_dict[key]
 
             if self.reduction == "sum":

--- a/ppsci/loss/l1.py
+++ b/ppsci/loss/l1.py
@@ -87,7 +87,7 @@ class L1Loss(base.Loss):
         losses = 0.0
         for key in label_dict:
             loss = F.l1_loss(output_dict[key], label_dict[key], "none")
-            if weight_dict:
+            if weight_dict and key in weight_dict:
                 loss *= weight_dict[key]
 
             if "area" in output_dict:
@@ -181,7 +181,7 @@ class PeriodicL1Loss(base.Loss):
             loss = F.l1_loss(
                 output_dict[key][:n_output], output_dict[key][n_output:], "none"
             )
-            if weight_dict:
+            if weight_dict and key in weight_dict:
                 loss *= weight_dict[key]
             if "area" in output_dict:
                 loss *= output_dict["area"]

--- a/ppsci/loss/l2.py
+++ b/ppsci/loss/l2.py
@@ -87,7 +87,7 @@ class L2Loss(base.Loss):
         losses = 0.0
         for key in label_dict:
             loss = F.mse_loss(output_dict[key], label_dict[key], "none")
-            if weight_dict:
+            if weight_dict and key in weight_dict:
                 loss *= weight_dict[key]
 
             if "area" in output_dict:
@@ -181,7 +181,7 @@ class PeriodicL2Loss(base.Loss):
             loss = F.mse_loss(
                 output_dict[key][:n_output], output_dict[key][n_output:], "none"
             )
-            if weight_dict:
+            if weight_dict and key in weight_dict:
                 loss *= weight_dict[key]
 
             if "area" in output_dict:

--- a/ppsci/loss/mae.py
+++ b/ppsci/loss/mae.py
@@ -80,7 +80,7 @@ class MAELoss(base.Loss):
         losses = 0.0
         for key in label_dict:
             loss = F.l1_loss(output_dict[key], label_dict[key], "none")
-            if weight_dict:
+            if weight_dict and key in weight_dict:
                 loss *= weight_dict[key]
 
             if "area" in output_dict:

--- a/ppsci/loss/mse.py
+++ b/ppsci/loss/mse.py
@@ -80,7 +80,7 @@ class MSELoss(base.Loss):
         losses = 0.0
         for key in label_dict:
             loss = F.mse_loss(output_dict[key], label_dict[key], "none")
-            if weight_dict:
+            if weight_dict and key in weight_dict:
                 loss *= weight_dict[key]
 
             if "area" in output_dict:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 当 constraint 未指定 `weight_dict` 时，其构建出的 `dataset.__getitem__()` 返回的 weight 为空字典，而非全 1 的 ndarray，此时在 loss 计算时可跳过此类冗余的 “乘1” 计算。