### PR TITLE
[Fix] Remove redundant '()' when initializing lr_scheduler

### DIFF
--- a/examples/aneurysm/aneurysm.py
+++ b/examples/aneurysm/aneurysm.py
@@ -159,7 +159,7 @@ def train(cfg: DictConfig):
     # set optimizer
     lr_scheduler = ppsci.optimizer.lr_scheduler.ExponentialDecay(
         **cfg.TRAIN.lr_scheduler
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 
     # set validator

--- a/examples/bracket/bracket.py
+++ b/examples/bracket/bracket.py
@@ -189,7 +189,7 @@ def train(cfg: DictConfig):
     # set optimizer
     lr_scheduler = ppsci.optimizer.lr_scheduler.ExponentialDecay(
         **cfg.TRAIN.lr_scheduler
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 
     # set validator

--- a/examples/control_arm/forward_analysis.py
+++ b/examples/control_arm/forward_analysis.py
@@ -26,7 +26,7 @@ def train(cfg: DictConfig):
     # set optimizer
     lr_scheduler = ppsci.optimizer.lr_scheduler.ExponentialDecay(
         **cfg.TRAIN.lr_scheduler
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model_list)
 
     # specify parameters

--- a/examples/control_arm/inverse_parameter.py
+++ b/examples/control_arm/inverse_parameter.py
@@ -29,7 +29,7 @@ def train(cfg: DictConfig):
     # set optimizer
     lr_scheduler = ppsci.optimizer.lr_scheduler.ExponentialDecay(
         **cfg.TRAIN.lr_scheduler
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(lr_scheduler)((inverse_lambda_net, inverse_mu_net))
 
     # set equation

--- a/examples/cylinder/2d_unsteady/transformer_physx/train_enn.py
+++ b/examples/cylinder/2d_unsteady/transformer_physx/train_enn.py
@@ -114,7 +114,7 @@ def train(cfg: DictConfig):
         iters_per_epoch=ITERS_PER_EPOCH,
         decay_steps=ITERS_PER_EPOCH,
         **cfg.TRAIN.lr_scheduler,
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(
         lr_scheduler, grad_clip=clip, **cfg.TRAIN.optimizer
     )(model)

--- a/examples/cylinder/2d_unsteady/transformer_physx/train_transformer.py
+++ b/examples/cylinder/2d_unsteady/transformer_physx/train_transformer.py
@@ -101,7 +101,7 @@ def train(cfg: DictConfig):
     clip = paddle.nn.ClipGradByGlobalNorm(clip_norm=0.1)
     lr_scheduler = ppsci.optimizer.lr_scheduler.CosineWarmRestarts(
         iters_per_epoch=ITERS_PER_EPOCH, **cfg.TRAIN.lr_scheduler
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(
         lr_scheduler, grad_clip=clip, **cfg.TRAIN.optimizer
     )(model)

--- a/examples/darcy/darcy2d.py
+++ b/examples/darcy/darcy2d.py
@@ -82,7 +82,7 @@ def train(cfg: DictConfig):
     }
 
     # set optimizer
-    lr_scheduler = ppsci.optimizer.lr_scheduler.OneCycleLR(**cfg.TRAIN.lr_scheduler)()
+    lr_scheduler = ppsci.optimizer.lr_scheduler.OneCycleLR(**cfg.TRAIN.lr_scheduler)
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 
     # set validator

--- a/examples/epnn/functions.py
+++ b/examples/epnn/functions.py
@@ -398,14 +398,14 @@ def get_optimizer_list(model_list, cfg):
     for i, model in enumerate(model_list):
         scheduler = ppsci.optimizer.lr_scheduler.ExponentialDecay(
             **cfg.TRAIN.lr_scheduler, learning_rate=lr_list[i]
-        )()
+        )
         optimizer_list.append(
             ppsci.optimizer.Adam(learning_rate=scheduler, weight_decay=0.0)(model)
         )
 
     scheduler_ratio = ppsci.optimizer.lr_scheduler.ExponentialDecay(
         **cfg.TRAIN.lr_scheduler, learning_rate=0.001
-    )()
+    )
     optimizer_list.append(
         paddle.optimizer.Adam(
             parameters=[gkratio], learning_rate=scheduler_ratio, weight_decay=0.0

--- a/examples/fourcastnet/train_finetune.py
+++ b/examples/fourcastnet/train_finetune.py
@@ -168,7 +168,7 @@ def train(cfg: DictConfig):
     # init optimizer and lr scheduler
     lr_scheduler_cfg = dict(cfg.TRAIN.lr_scheduler)
     lr_scheduler_cfg.update({"iters_per_epoch": ITERS_PER_EPOCH})
-    lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(**lr_scheduler_cfg)()
+    lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(**lr_scheduler_cfg)
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 
     # initialize solver

--- a/examples/fourcastnet/train_precip.py
+++ b/examples/fourcastnet/train_precip.py
@@ -164,7 +164,7 @@ def train(cfg: DictConfig):
     # init optimizer and lr scheduler
     lr_scheduler_cfg = dict(cfg.TRAIN.lr_scheduler)
     lr_scheduler_cfg.update({"iters_per_epoch": ITERS_PER_EPOCH})
-    lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(**lr_scheduler_cfg)()
+    lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(**lr_scheduler_cfg)
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 
     # initialize solver

--- a/examples/fourcastnet/train_pretrain.py
+++ b/examples/fourcastnet/train_pretrain.py
@@ -156,7 +156,7 @@ def train(cfg: DictConfig):
     # init optimizer and lr scheduler
     lr_scheduler_cfg = dict(cfg.TRAIN.lr_scheduler)
     lr_scheduler_cfg.update({"iters_per_epoch": ITERS_PER_EPOCH})
-    lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(**lr_scheduler_cfg)()
+    lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(**lr_scheduler_cfg)
 
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 

--- a/examples/fsi/viv.py
+++ b/examples/fsi/viv.py
@@ -54,7 +54,7 @@ def train(cfg: DictConfig):
     constraint = {sup_constraint.name: sup_constraint}
 
     # set optimizer
-    lr_scheduler = ppsci.optimizer.lr_scheduler.Step(**cfg.TRAIN.lr_scheduler)()
+    lr_scheduler = ppsci.optimizer.lr_scheduler.Step(**cfg.TRAIN.lr_scheduler)
     optimizer = ppsci.optimizer.Adam(lr_scheduler)((model,) + tuple(equation.values()))
 
     # set validator

--- a/examples/ldc/ldc2d_steady_Re10.py
+++ b/examples/ldc/ldc2d_steady_Re10.py
@@ -108,7 +108,7 @@ def train(cfg: DictConfig):
     lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(
         **cfg.TRAIN.lr_scheduler,
         warmup_epoch=int(0.05 * cfg.TRAIN.epochs),
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 
     # set validator

--- a/examples/ldc/ldc2d_unsteady_Re10.py
+++ b/examples/ldc/ldc2d_unsteady_Re10.py
@@ -127,7 +127,7 @@ def train(cfg: DictConfig):
     lr_scheduler = ppsci.optimizer.lr_scheduler.Cosine(
         **cfg.TRAIN.lr_scheduler,
         warmup_epoch=int(0.05 * cfg.TRAIN.epochs),
-    )()
+    )
 
     # set optimizer
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)

--- a/examples/lorenz/train_enn.py
+++ b/examples/lorenz/train_enn.py
@@ -102,7 +102,7 @@ def train(cfg: DictConfig):
         iters_per_epoch=ITERS_PER_EPOCH,
         decay_steps=ITERS_PER_EPOCH,
         **cfg.TRAIN.lr_scheduler,
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(
         lr_scheduler, grad_clip=clip, **cfg.TRAIN.optimizer
     )(model)

--- a/examples/lorenz/train_transformer.py
+++ b/examples/lorenz/train_transformer.py
@@ -101,7 +101,7 @@ def train(cfg: DictConfig):
     clip = paddle.nn.ClipGradByGlobalNorm(clip_norm=0.1)
     lr_scheduler = ppsci.optimizer.lr_scheduler.CosineWarmRestarts(
         iters_per_epoch=ITERS_PER_EPOCH, **cfg.TRAIN.lr_scheduler
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(
         lr_scheduler, grad_clip=clip, **cfg.TRAIN.optimizer
     )(model)

--- a/examples/nsfnet/VP_NSFNet1.py
+++ b/examples/nsfnet/VP_NSFNet1.py
@@ -186,7 +186,7 @@ def train(cfg: DictConfig):
 
     lr_scheduler = ppsci.optimizer.lr_scheduler.Piecewise(
         EPOCHS, ITERS_PER_EPOCH, new_epoch_list, lr_list
-    )()
+    )
 
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 

--- a/examples/nsfnet/VP_NSFNet2.py
+++ b/examples/nsfnet/VP_NSFNet2.py
@@ -267,7 +267,7 @@ def train(cfg: DictConfig):
     lr_list = [1e-3, 1e-4, 1e-5, 1e-6, 1e-7]
     lr_scheduler = ppsci.optimizer.lr_scheduler.Piecewise(
         EPOCHS, ITERS_PER_EPOCH, new_epoch_list, lr_list
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
 
     logger.init_logger("ppsci", f"{OUTPUT_DIR}/eval.log", "info")

--- a/examples/nsfnet/VP_NSFNet3.py
+++ b/examples/nsfnet/VP_NSFNet3.py
@@ -327,7 +327,7 @@ def train(cfg: DictConfig):
     lr_list = [1e-3, 1e-4, 1e-5, 1e-6, 1e-7]
     lr_scheduler = ppsci.optimizer.lr_scheduler.Piecewise(
         EPOCHS, ITERS_PER_EPOCH, new_epoch_list, lr_list
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(lr_scheduler)(model)
     logger.init_logger("ppsci", f"{OUTPUT_DIR}/eval.log", "info")
     # initialize solver

--- a/examples/rossler/train_enn.py
+++ b/examples/rossler/train_enn.py
@@ -104,7 +104,7 @@ def train(cfg: DictConfig):
         iters_per_epoch=ITERS_PER_EPOCH,
         decay_steps=ITERS_PER_EPOCH,
         **cfg.TRAIN.lr_scheduler,
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(
         lr_scheduler, grad_clip=clip, **cfg.TRAIN.optimizer
     )(model)

--- a/examples/rossler/train_transformer.py
+++ b/examples/rossler/train_transformer.py
@@ -98,7 +98,7 @@ def train(cfg: DictConfig):
     clip = paddle.nn.ClipGradByGlobalNorm(clip_norm=0.1)
     lr_scheduler = ppsci.optimizer.lr_scheduler.CosineWarmRestarts(
         iters_per_epoch=ITERS_PER_EPOCH, **cfg.TRAIN.lr_scheduler
-    )()
+    )
     optimizer = ppsci.optimizer.Adam(
         lr_scheduler, grad_clip=clip, **cfg.TRAIN.optimizer
     )(model)

--- a/examples/tempoGAN/tempoGAN.py
+++ b/examples/tempoGAN/tempoGAN.py
@@ -78,17 +78,17 @@ def train(cfg: DictConfig):
     # initialize Adam optimizer
     lr_scheduler_gen = ppsci.optimizer.lr_scheduler.Step(
         step_size=cfg.TRAIN.epochs // 2, **cfg.TRAIN.lr_scheduler
-    )()
+    )
     optimizer_gen = ppsci.optimizer.Adam(lr_scheduler_gen)((model_gen,))
     if cfg.USE_SPATIALDISC:
         lr_scheduler_disc = ppsci.optimizer.lr_scheduler.Step(
             step_size=cfg.TRAIN.epochs // 2, **cfg.TRAIN.lr_scheduler
-        )()
+        )
         optimizer_disc = ppsci.optimizer.Adam(lr_scheduler_disc)((model_disc,))
     if cfg.USE_TEMPODISC:
         lr_scheduler_disc_tempo = ppsci.optimizer.lr_scheduler.Step(
             step_size=cfg.TRAIN.epochs // 2, **cfg.TRAIN.lr_scheduler
-        )()
+        )
         optimizer_disc_tempo = ppsci.optimizer.Adam(lr_scheduler_disc_tempo)(
             (model_disc_tempo,)
         )

--- a/ppsci/optimizer/lr_scheduler.py
+++ b/ppsci/optimizer/lr_scheduler.py
@@ -15,9 +15,11 @@
 from __future__ import annotations
 
 import abc
+import functools
 import math
 from typing import List
 from typing import Tuple
+from typing import Type
 from typing import Union
 
 from paddle.optimizer import lr
@@ -34,6 +36,26 @@ __all__ = [
     "CosineWarmRestarts",
     "OneCycleLR",
 ]
+
+
+def class_wrapper(cls_: Type[LRBase]):
+    """
+    This wrapper is designed to avoid redundant __call__ method when initializing a
+    scheduler in ppsci.optimizer.lr_scheduler module.
+
+    For example:
+
+    before: lr_scheduler = ppsci.optimizer.lr_scheduler.Step(**cfg.TRAIN.lr_scheduler)()
+    after: lr_scheduler = ppsci.optimizer.lr_scheduler.Step(**cfg.TRAIN.lr_scheduler)
+
+    Redundant pair of bracket "()" is removed by this wrapper.
+    """
+
+    @functools.wraps(cls_)
+    def wrapped_class(*args, **kwargs):
+        return cls_(*args, **kwargs)()
+
+    return wrapped_class
 
 
 class LRBase:
@@ -117,6 +139,7 @@ class LRBase:
         return warmup_lr
 
 
+@class_wrapper
 class Constant(lr.LRScheduler):
     """Constant learning rate Class implementation.
 
@@ -135,6 +158,7 @@ class Constant(lr.LRScheduler):
         return self.learning_rate
 
 
+@class_wrapper
 class Linear(LRBase):
     """Linear learning rate decay.
 
@@ -151,7 +175,7 @@ class Linear(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.Linear(10, 2, 0.001)()
+        >>> lr = ppsci.optimizer.lr_scheduler.Linear(10, 2, 0.001)
     """
 
     def __init__(
@@ -205,6 +229,7 @@ class Linear(LRBase):
         return learning_rate
 
 
+@class_wrapper
 class ExponentialDecay(LRBase):
     """ExponentialDecay learning rate decay.
 
@@ -219,7 +244,7 @@ class ExponentialDecay(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.ExponentialDecay(10, 2, 1e-3, 0.95, 3)()
+        >>> lr = ppsci.optimizer.lr_scheduler.ExponentialDecay(10, 2, 1e-3, 0.95, 3)
     """
 
     def __init__(
@@ -263,6 +288,7 @@ class ExponentialDecay(LRBase):
         return learning_rate
 
 
+@class_wrapper
 class Cosine(LRBase):
     r"""Cosine learning rate decay.
 
@@ -281,7 +307,7 @@ class Cosine(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.Cosine(10, 2, 1e-3)()
+        >>> lr = ppsci.optimizer.lr_scheduler.Cosine(10, 2, 1e-3)
     """
 
     def __init__(
@@ -328,6 +354,7 @@ class Cosine(LRBase):
         return learning_rate
 
 
+@class_wrapper
 class Step(LRBase):
     """Step learning rate decay.
 
@@ -346,7 +373,7 @@ class Step(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.Step(10, 1, 1e-3, 2, 0.95)()
+        >>> lr = ppsci.optimizer.lr_scheduler.Step(10, 1, 1e-3, 2, 0.95)
     """
 
     def __init__(
@@ -390,6 +417,7 @@ class Step(LRBase):
         return learning_rate
 
 
+@class_wrapper
 class Piecewise(LRBase):
     """Piecewise learning rate decay
 
@@ -410,7 +438,7 @@ class Piecewise(LRBase):
         >>> import ppsci
         >>> lr = ppsci.optimizer.lr_scheduler.Piecewise(
         ...     10, 1, [2, 4], (1e-3, 1e-4, 1e-5)
-        ... )()
+        ... )
     """
 
     def __init__(
@@ -452,6 +480,7 @@ class Piecewise(LRBase):
         return learning_rate
 
 
+@class_wrapper
 class MultiStepDecay(LRBase):
     """MultiStepDecay learning rate decay
 
@@ -470,7 +499,7 @@ class MultiStepDecay(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.MultiStepDecay(10, 1, 1e-3, (4, 5))()
+        >>> lr = ppsci.optimizer.lr_scheduler.MultiStepDecay(10, 1, 1e-3, (4, 5))
     """
 
     def __init__(
@@ -514,6 +543,7 @@ class MultiStepDecay(LRBase):
         return learning_rate
 
 
+@class_wrapper
 class CosineAnnealingWarmRestarts(lr.LRScheduler):
     """The implementation of cosine annealing schedule with warm restarts.
 
@@ -587,6 +617,7 @@ class CosineAnnealingWarmRestarts(lr.LRScheduler):
         self.last_lr = self.get_lr()
 
 
+@class_wrapper
 class CosineWarmRestarts(LRBase):
     """Set the learning rate using a cosine annealing schedule with warm restarts.
 
@@ -604,7 +635,7 @@ class CosineWarmRestarts(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.CosineWarmRestarts(20, 1, 1e-3, 14, 2)()
+        >>> lr = ppsci.optimizer.lr_scheduler.CosineWarmRestarts(20, 1, 1e-3, 14, 2)
     """
 
     def __init__(
@@ -652,6 +683,7 @@ class CosineWarmRestarts(LRBase):
         return learning_rate
 
 
+@class_wrapper
 class OneCycleLR(LRBase):
     """Sets the learning rate according to the one cycle learning rate scheduler.
     The scheduler adjusts the learning rate from an initial learning rate to the maximum learning rate and then
@@ -679,7 +711,7 @@ class OneCycleLR(LRBase):
 
     Examples:
         >>> import ppsci
-        >>> lr = ppsci.optimizer.lr_scheduler.OneCycleLR(100, 1, 1e-3)()
+        >>> lr = ppsci.optimizer.lr_scheduler.OneCycleLR(100, 1, 1e-3)
     """
 
     def __init__(
@@ -735,6 +767,7 @@ class OneCycleLR(LRBase):
         return learning_rate
 
 
+@class_wrapper
 class SchedulerList:
     """SchedulerList which wrap more than one scheduler.
     Args:
@@ -742,8 +775,8 @@ class SchedulerList:
         by_epoch (bool, optional): Learning rate decays by epoch when by_epoch is True, else by iter. Defaults to False.
     Examples:
         >>> import ppsci
-        >>> sch1 = ppsci.optimizer.lr_scheduler.Linear(10, 2, 0.001)()
-        >>> sch2 = ppsci.optimizer.lr_scheduler.ExponentialDecay(10, 2, 1e-3, 0.95, 3)()
+        >>> sch1 = ppsci.optimizer.lr_scheduler.Linear(10, 2, 0.001)
+        >>> sch2 = ppsci.optimizer.lr_scheduler.ExponentialDecay(10, 2, 1e-3, 0.95, 3)
         >>> sch = ppsci.optimizer.lr_scheduler.SchedulerList((sch1, sch2))
     """
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 移除 `lr_scheduler` 初始化时末尾的括号`()`