### PR TITLE
[Fix] Clear differentiation cache in visu_forward to avoid OOM problem

### DIFF
--- a/examples/bubble/bubble.py
+++ b/examples/bubble/bubble.py
@@ -362,7 +362,7 @@ def evaluate(cfg: DictConfig):
         NPOINT_PDE * NTIME_PDE, evenly=True
     )
 
-    pred_norm = solver.predict(visu_mat, no_grad=False, return_numpy=True)
+    pred_norm = solver.predict(visu_mat, None, 4096, no_grad=False, return_numpy=True)
     # inverse normalization
     p_pred = pred_norm["p"].reshape([NTIME_PDE, NPOINT_PDE]).T
     u_pred = pred_norm["u"].reshape([NTIME_PDE, NPOINT_PDE]).T

--- a/ppsci/utils/expression.py
+++ b/ppsci/utils/expression.py
@@ -185,7 +185,7 @@ class ExpressionSolver(nn.Layer):
             for name, expr in expr_dict.items():
                 output_dict[name] = expr(data_dict)
 
-            # clear differentiation cache
-            clear()
+        # clear differentiation cache
+        clear()
 
         return output_dict


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. `visu_forward` 结尾固定清除微分缓存，否则如果expr_dict为None而微分操作注册到了model内，则可能会导致显存缓慢增大最终溢出