### PR TITLE
remove python3.7 in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,34 +23,34 @@ RUN apt-get update && \
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget https://mirrors.huaweicloud.com/python/3.7.11/Python-3.7.11.tgz && \
-    tar -xf Python-3.7.11.tgz && \
-    cd Python-3.7.11 && \
+RUN wget https://mirrors.huaweicloud.com/python/3.9.7/Python-3.9.7.tgz && \
+    tar -xf Python-3.9.7.tgz && \
+    cd Python-3.9.7 && \
     ./configure --with-ssl && \
     make -j -notest && \
     make install && \
-    cd .. && rm -rf Python-3.7.11 && rm Python-3.7.11.tgz && \
-    ln -s /usr/local/bin/python3.7 /usr/local/bin/python
+    cd .. && rm -rf Python-3.9.7 && rm Python-3.9.7.tgz && \
+    ln -s /usr/local/bin/python3.9 /usr/local/bin/python
 
 RUN python3 -m pip install --upgrade pip -i https://pypi.douban.com/simple/ && pip install pysdf open3d db-sqlite3 -i https://pypi.douban.com/simple/
 
 # install pymesh and paddle
+RUN python3 -m pip install --upgrade pip -i https://pypi.douban.com/simple/ && pip install numpy==1.22.4 -i https://pypi.douban.com/simple/
 COPY ./pymesh.tar.xz /src/pymesh.tar.xz
 
 RUN cd /src && \
     ls /src && \
     tar -xvf pymesh.tar.xz && \
     cd pymesh && \
-    python3 setup.py install
+    python3 setup.py install && \
+    rm -rf /src
 
 ENV PATH="$PATH:/usr/lib/x86_64-linux-gnu/"
 ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64/:$LD_LIBRARY_PATH"
 
-RUN cd /src && \
-    python3 -m ensurepip --upgrade && \
+RUN python3 -m ensurepip --upgrade && \
     pip3 config set global.index-url https://pypi.doubanio.com/simple/ && \
     # ensure paddle install normally
     ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.8 /usr/local/cuda/lib64/libcudnn.so && \
     ln -s /usr/local/cuda/lib64/libcublas.so.11 /usr/local/cuda/lib64/libcublas.so && \
-    python3 -m pip install paddlepaddle-gpu==0.0.0.post116 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html && \
-    rm -rf /src
+    python3 -m pip install paddlepaddle-gpu==0.0.0.post116 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,9 +1,9 @@
 docker build . -t paddlescience:latest
 
 if [ -x "$(command -v nvidia-docker)" ]; then
-    nvidia-docker run -it -v $PWD:/work paddlescience
+    nvidia-docker run --network=host -it paddlescience
 elif [ -x "$(command -v docker)" ]; then
-    docker run --gpus all -it -v $PWD:/work paddlescience
+    docker run --gpus all --network=host -it paddlescience
 else
     echo "Please install docker or nvidia-docker first."
 fi

--- a/docs/zh/install_setup.md
+++ b/docs/zh/install_setup.md
@@ -76,7 +76,7 @@
 #### 1.4.2 安装额外功能[可选]
 
 如需使用 `.obj`, `.ply`, `.off`, `.stl`, `.mesh`, `.node`, `.poly` and `.msh` 等复杂几何文件构建几何（计算域），以及使用加密采样等功能，则需按照下方给出的命令，安装 open3d、
-pybind11、pysdf、PyMesh 四个依赖库。
+pybind11、pysdf、PyMesh 四个依赖库（上述**1.1 从 docker 镜像启动**中已安装上述依赖库)。
 
 否则无法使用 `ppsci.geometry.Mesh` 等基于复杂几何文件的 API，因此也无法运行如 [Aneurysm](./examples/aneurysm.md) 等依赖 `ppsci.geometry.Mesh` API 的复杂案例。
 

--- a/docs/zh/install_setup.md
+++ b/docs/zh/install_setup.md
@@ -10,11 +10,6 @@
 2. 执行 `bash run.sh`，等待 docker build 完毕后自动进入环境。如果出现因网络问题导致的 apt 下载报错，则重复执行 `bash run.sh` 直至 build 完成即可。
 3. 在 docker 环境中，执行 `ldconfig`
 
-!!! warning "python 3.7 退场说明"
-
-    本 docker 自带的 python3.7 已不再被 paddle 支持，因此建议进入 docker 后自行按照步骤 1.2，使用 Anaconda 重新安装 python3.9。
-    带有 python3.9 的 docker 镜像会在后续提供。
-
 ### 1.2 python 环境安装[可选]
 
 如果你还没有 python 环境或者 python 版本小于 3.9，则推荐使用 Anaconda 安装并配置 python 环境，否则可以忽略本步骤。


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
remove python3.7 in docker
- update python version to 3.9
- pymesh中依赖 `numpy.testing.Tester`
    ``` python
    from numpy.testing import Tester 
    ```
    numpy 1.25及以后废弃了 [`Tester`](https://numpy.org/doc/stable/release/1.25.0-notes.html)
    ![image](https://github.com/PaddlePaddle/PaddleScience/assets/106524776/1c25bb09-6da2-4065-8501-1ff3f63b8a8d)