### PR TITLE
[Fix] Specify pydantic >= 2.5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "matplotlib",
     "meshio==5.3.4",
     "numpy>=1.20.0,<=1.23.1",
-    "pydantic",
+    "pydantic>=2.5.0",
     "pyevtk",
     "pyvista==0.37.0",
     "pyyaml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ imageio
 matplotlib
 meshio==5.3.4
 numpy>=1.20.0,<=1.23.1
-pydantic
+pydantic>=2.5.0
 pyevtk
 pyvista==0.37.0
 pyyaml


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Describe
<!-- Describe what this PR does -->
specify pydantic >= 2.5.x or field_validator can not be imported from pydantic 1.x version
