### PR TITLE
[Fix] Set create_graph=False before eval in bubble example

### DIFF
--- a/docs/zh/examples/bubble.md
+++ b/docs/zh/examples/bubble.md
@@ -301,9 +301,9 @@ examples/bubble/bubble.py:189:206
 
 最后在给定的可视化区域上进行预测并可视化，可视化数据是区域内的二维点集，每个时刻 $t$ 的坐标是 $(x^t_i, y^t_i)$，对应值是 $(u^t_i, v^t_i, p^t_i,\phi^t_i)$，在此我们对预测得到的 $(u^t_i, v^t_i, p^t_i,\phi^t_i)$ 进行反归一化，我们将反归一化后的数据按时刻保存成 126 个 **vtu格式** 文件，最后用可视化软件打开查看即可。代码如下：
 
-``` py linenums="212"
+``` py linenums="222"
 --8<--
-examples/bubble/bubble.py:212:238
+examples/bubble/bubble.py:222:248
 --8<--
 ```
 

--- a/examples/bubble/bubble.py
+++ b/examples/bubble/bubble.py
@@ -208,6 +208,16 @@ def train(cfg: DictConfig):
     visu_mat = geom["time_rect_visu"].sample_interior(
         NPOINT_PDE * NTIME_PDE, evenly=True
     )
+    # transform
+    def transform_out(in_, out):
+        psi_y = out["psi"]
+        y = in_["y"]
+        x = in_["x"]
+        u = jacobian(psi_y, y, create_graph=False)
+        v = -jacobian(psi_y, x, create_graph=False)
+        return {"u": u, "v": v}
+
+    model_psi.register_output_transform(transform_out)
 
     pred_norm = solver.predict(visu_mat, None, 4096, no_grad=False, return_numpy=True)
     # inverse normalization


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. bubble 案例在预测前设置 `create_graph=False` 防止OOM