### PR TITLE
[Fix] Fix gpu occupying when running with cpu

### DIFF
--- a/ppsci/arch/activation.py
+++ b/ppsci/arch/activation.py
@@ -146,7 +146,7 @@ act_func_dict = {
     "silu": Silu(),
     "sin": Sin(),
     "cos": Cos(),
-    "swish": Swish(),
+    "swish": Swish,
     "tanh": nn.Tanh(),
     "identity": nn.Identity(),
     "siren": Siren(),
@@ -166,4 +166,9 @@ def get_activation(act_name: str) -> Callable:
     if act_name.lower() not in act_func_dict:
         raise ValueError(f"act_name({act_name}) not found in act_func_dict")
 
-    return act_func_dict[act_name.lower()]
+    act_layer = act_func_dict[act_name.lower()]
+    if isinstance(act_layer, type) and act_name != "stan":
+        # Is a activation class but not a instance of it, instantiate manually(except for 'Stan')
+        return act_layer()
+
+    return act_layer

--- a/ppsci/utils/symbolic.py
+++ b/ppsci/utils/symbolic.py
@@ -97,7 +97,7 @@ SYMPY_TO_PADDLE = {
     sp.Max: paddle.maximum,
     sp.Min: paddle.minimum,
     sp.Abs: paddle.abs,
-    sp.Heaviside: functools.partial(paddle.heaviside, y=paddle.zeros([])),
+    sp.Heaviside: paddle.heaviside,
     sp.sign: paddle.sign,
     sp.ceiling: paddle.ceil,
     sp.floor: paddle.floor,
@@ -214,6 +214,9 @@ class OperatorNode(Node):
         elif self.expr.func == sp.Heaviside:
             self._apply_func = self._heaviside_operator_func
             self._auxiliary_func = SYMPY_TO_PADDLE[sp.Heaviside]
+            self._auxiliary_func = functools.partial(
+                self._auxiliary_func, y=paddle.zeros([])
+            )
         elif self.expr.func == sp.Min:
             self._apply_func = self._minimum_operator_func
         elif self.expr.func == sp.Max:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
1. 修复CPU运行时仍然会有1.2G GPU显存占用的问题。经排查问题出在两个部分
- `ppsci/arch/activation.py`内全局变量`act_func_dict`初始化时，包含了含参激活层`Swish`，这会触发paddle内部的初始化，导致显存占用。将`Swish`改为lazy初始化后解决。
- `ppsci/utils/symbolic.py`中的全局变量`SYMPY_TO_PADDLE`初始化时将`paddle.zeros([])`作为partial参数对`paddle.heaviside`进行了装饰，因此也会触发paddle内部的初始化，导致显存占用。将这一包装行为放至`OperatorNode.__init__`，让其变成lazy初始化后解决。

修改前（出现红框中的内容表示触发了paddle内部的初始化，显存被占用）：
![image](https://github.com/PaddlePaddle/PaddleScience/assets/23737287/694a1abd-b475-4a4e-b910-eb3ff126502b)

修改后：
![image](https://github.com/PaddlePaddle/PaddleScience/assets/23737287/48581874-fbe3-4773-ba88-cf6f37712a7e)
