### PR TITLE
Allow initialize dataloader without specifying 'sampler'

### DIFF
--- a/ppsci/data/__init__.py
+++ b/ppsci/data/__init__.py
@@ -82,16 +82,21 @@ def build_dataloader(_dataset, cfg):
         sampler_cfg["batch_size"] = cfg["batch_size"]
         batch_sampler = getattr(io, batch_sampler_cls)(_dataset, **sampler_cfg)
     else:
-        if cfg["batch_size"] != 1:
-            raise ValueError(
-                f"`batch_size` should be 1 when sampler config is None, but got {cfg['batch_size']}."
+        batch_sampler_cls = "BatchSampler"
+        if world_size > 1:
+            batch_sampler_cls = "DistributedBatchSampler"
+            logger.warning(
+                f"Automatically use 'DistributedBatchSampler' instead of "
+                f"'BatchSampler' when world_size({world_size}) > 1."
             )
-        logger.warning(
-            "`batch_size` is set to 1 as neither sampler config nor batch_size is set."
-        )
-        batch_sampler = io.BatchSampler(
+        batch_sampler = getattr(io, batch_sampler_cls)(
             _dataset,
             batch_size=cfg["batch_size"],
+            shuffle=False,
+            drop_last=False,
+        )
+        logger.message(
+            "'shuffle' and 'drop_last' are both set to False in default as sampler config is not specified."
         )
 
     # build collate_fn if specified


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->

1. 允许dataloader_cfg内仅指定`batch_size`