### PR TITLE
[Fix]dtype of RadarDataset's data

### DIFF
--- a/ppsci/data/dataset/radar_dataset.py
+++ b/ppsci/data/dataset/radar_dataset.py
@@ -123,7 +123,9 @@ class RadarDataset(io.Dataset):
         mask[data < 0] = 0
         data[data < 0] = 0
         data = np.clip(data, 0, 128)
-        vid = np.zeros((self.length, self.img_height, self.img_width, 2))
+        vid = np.zeros(
+            (self.length, self.img_height, self.img_width, 2), dtype=self.data_type
+        )
         vid[..., 0] = data
         vid[..., 1] = mask
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Specify dtype of 'vis' to avoide it be created as dtype np.float64 