### PR TITLE
[Enh] Add quasi-random sampling: Halton

### DIFF
--- a/ppsci/constraint/boundary_constraint.py
+++ b/ppsci/constraint/boundary_constraint.py
@@ -45,7 +45,7 @@ class BoundaryConstraint(base.Constraint):
         geom (geometry.Geometry): Geometry where data sampled from.
         dataloader_cfg (Dict[str, Any]): Dataloader config.
         loss (loss.Loss): Loss functor.
-        random (Literal["pseudo", "LHS"], optional): Random method for sampling data in
+        random (Literal["pseudo", "Halton", "LHS"], optional): Random method for sampling data in
             geometry. Defaults to "pseudo".
         criteria (Optional[Callable]): Criteria for refining specified boundaries.
             Defaults to None.
@@ -79,7 +79,7 @@ class BoundaryConstraint(base.Constraint):
         geom: geometry.Geometry,
         dataloader_cfg: Dict[str, Any],
         loss: "loss.Loss",
-        random: Literal["pseudo", "LHS"] = "pseudo",
+        random: Literal["pseudo", "Halton", "LHS"] = "pseudo",
         criteria: Optional[Callable] = None,
         evenly: bool = False,
         weight_dict: Optional[Dict[str, Union[float, Callable]]] = None,

--- a/ppsci/constraint/initial_constraint.py
+++ b/ppsci/constraint/initial_constraint.py
@@ -45,7 +45,7 @@ class InitialConstraint(base.Constraint):
         geom (geometry.TimeXGeometry): Geometry where data sampled from.
         dataloader_cfg (Dict[str, Any]): Dataloader config.
         loss (loss.Loss): Loss functor.
-        random (Literal["pseudo", "LHS"], optional): Random method for sampling data in
+        random (Literal["pseudo", "Halton", "LHS"], optional): Random method for sampling data in
             geometry. Defaults to "pseudo".
         criteria (Optional[Callable]): Criteria for refining specified boundaries.
             Defaults to None.
@@ -84,7 +84,7 @@ class InitialConstraint(base.Constraint):
         geom: geometry.TimeXGeometry,
         dataloader_cfg: Dict[str, Any],
         loss: "loss.Loss",
-        random: Literal["pseudo", "LHS"] = "pseudo",
+        random: Literal["pseudo", "Halton", "LHS"] = "pseudo",
         criteria: Optional[Callable] = None,
         evenly: bool = False,
         weight_dict: Optional[Dict[str, Callable]] = None,

--- a/ppsci/constraint/integral_constraint.py
+++ b/ppsci/constraint/integral_constraint.py
@@ -48,7 +48,7 @@ class IntegralConstraint(base.Constraint):
         geom (geometry.Geometry): Geometry where data sampled from.
         dataloader_cfg (Dict[str, Any]): Dataloader config.
         loss (loss.Loss): Loss functor.
-        random (Literal["pseudo", "LHS"], optional): Random method for sampling data in
+        random (Literal["pseudo", "Halton", "LHS"], optional): Random method for sampling data in
             geometry. Defaults to "pseudo".
         criteria (Optional[Callable]): Criteria for refining specified boundaries.
             Defaults to None.
@@ -81,7 +81,7 @@ class IntegralConstraint(base.Constraint):
         geom: geometry.Geometry,
         dataloader_cfg: Dict[str, Any],
         loss: "loss.Loss",
-        random: Literal["pseudo", "LHS"] = "pseudo",
+        random: Literal["pseudo", "Halton", "LHS"] = "pseudo",
         criteria: Optional[Callable] = None,
         weight_dict: Optional[Dict[str, Callable]] = None,
         name: str = "IgC",

--- a/ppsci/constraint/interior_constraint.py
+++ b/ppsci/constraint/interior_constraint.py
@@ -45,7 +45,7 @@ class InteriorConstraint(base.Constraint):
         geom (geometry.Geometry): Geometry where data sampled from.
         dataloader_cfg (Dict[str, Any]): Dataloader config.
         loss (loss.Loss): Loss functor.
-        random (Literal["pseudo", "LHS"], optional): Random method for sampling data in
+        random (Literal["pseudo", "Halton", "LHS"], optional): Random method for sampling data in
             geometry. Defaults to "pseudo".
         criteria (Optional[Callable]): Criteria for refining specified boundaries.
             Defaults to None.
@@ -81,7 +81,7 @@ class InteriorConstraint(base.Constraint):
         geom: geometry.Geometry,
         dataloader_cfg: Dict[str, Any],
         loss: "loss.Loss",
-        random: Literal["pseudo", "LHS"] = "pseudo",
+        random: Literal["pseudo", "Halton", "LHS"] = "pseudo",
         criteria: Optional[Callable] = None,
         evenly: bool = False,
         weight_dict: Optional[Dict[str, Union[Callable, float]]] = None,

--- a/ppsci/constraint/periodic_constraint.py
+++ b/ppsci/constraint/periodic_constraint.py
@@ -47,7 +47,7 @@ class PeriodicConstraint(base.Constraint):
         dataloader_cfg (Dict[str, Any]): Dataloader config.
         periodic_key (str): name of dimension which periodic constraint applied to.
         loss (loss.Loss): Loss functor.
-        random (Literal["pseudo", "LHS"], optional): Random method for sampling data in
+        random (Literal["pseudo", "Halton", "LHS"], optional): Random method for sampling data in
             geometry. Defaults to "pseudo".
         criteria (Optional[Callable]): Criteria for refining specified boundaries.
             Defaults to None.
@@ -66,7 +66,7 @@ class PeriodicConstraint(base.Constraint):
         periodic_key: str,
         dataloader_cfg: Dict[str, Any],
         loss: "loss.Loss",
-        random: Literal["pseudo", "LHS"] = "pseudo",
+        random: Literal["pseudo", "Halton", "LHS"] = "pseudo",
         criteria: Optional[Callable] = None,
         evenly: bool = False,
         weight_dict: Optional[Dict[str, Callable]] = None,

--- a/ppsci/geometry/sampler.py
+++ b/ppsci/geometry/sampler.py
@@ -25,7 +25,7 @@ from typing_extensions import Literal
 
 
 def sample(
-    n_samples: int, ndim: int, method: Literal["pseudo", "LHS"] = "pseudo"
+    n_samples: int, ndim: int, method: Literal["pseudo", "Halton", "LHS"] = "pseudo"
 ) -> np.ndarray:
     """Generate pseudorandom or quasi-random samples in [0, 1]^ndim.
 

--- a/ppsci/validate/geo_validator.py
+++ b/ppsci/validate/geo_validator.py
@@ -44,7 +44,7 @@ class GeometryValidator(base.Validator):
         geom (geometry.Geometry): Geometry where data sampled from.
         dataloader_cfg (Dict[str, Any]): Dataloader config.
         loss (loss.Loss): Loss functor.
-        random (Literal["pseudo", "LHS"], optional): Random method for sampling data in
+        random (Literal["pseudo", "Halton", "LHS"], optional): Random method for sampling data in
             geometry. Defaults to "pseudo".
         criteria (Optional[Callable]): Criteria for refining specified domain. Defaults to None.
         evenly (bool, optional): Whether to use evenly distribution sampling. Defaults to False.
@@ -76,7 +76,7 @@ class GeometryValidator(base.Validator):
         geom: geometry.Geometry,
         dataloader_cfg: Dict[str, Any],
         loss: loss.Loss,
-        random: Literal["pseudo", "LHS"] = "pseudo",
+        random: Literal["pseudo", "Halton", "LHS"] = "pseudo",
         criteria: Optional[Callable] = None,
         evenly: bool = False,
         metric: Optional[Dict[str, metric.Metric]] = None,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 添加 Halton 准随机采样方法（想比random伪随机方法，生成的点会更均匀），如下所示

``` py
import ppsci


rect = ppsci.geometry.Rectangle([-1, -1], [1, 1])

round_ = ppsci.geometry.Disk([0, 0], 1.0)

rect_halton_points = rect.sample_interior(
    10000,
    "Halton",
    criteria=lambda x, y: (x > 0) & (y > -0.5),
)
round_halton_points = round_.sample_interior(
    10000,
    "Halton",
    criteria=lambda x, y: (x > 0.5) & (y < 0.5),
)

ppsci.visualize.save_vtu_from_dict(
    "rect_halton_points.vtu",
    rect_halton_points,
    ("x", "y"),
    ("x", "y"),
)
ppsci.visualize.save_vtu_from_dict(
    "round_halton_points.vtu",
    round_halton_points,
    ("x", "y"),
    ("x", "y"),
)
```

![image](https://github.com/PaddlePaddle/PaddleScience/assets/23737287/be0b57d2-43b4-4030-b0b1-8a2fb700f537)
![image](https://github.com/PaddlePaddle/PaddleScience/assets/23737287/988707bc-2b20-46d0-8407-a105733e2585)

