### PR TITLE
[Doc] Fix description for mkldnn

### DIFF
--- a/docs/zh/examples/euler_beam.md
+++ b/docs/zh/examples/euler_beam.md
@@ -26,7 +26,7 @@
 
 | 预训练模型  | 指标 |
 |:--| :--|
-| [euler_beam_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/euler_beam/euler_beam_pretrained.pdparams) | loss(L2Rel_Metric): 0.00000<br>L2Rel.u(L2Rel_Metric): 0.00080 |
+| [euler_beam_pretrained.pdparams](https://paddle-org.bj.bcebos.com/paddlescience/models/euler_beam/euler_beam_pretrained.pdparams) | loss(L2Rel_Metric): 0.00000<br>L2Rel.u(L2Rel_Metric): 0.00058 |
 
 ## 1. 问题定义
 
@@ -70,17 +70,17 @@ $$
 
 上式中 $f$ 即为 MLP 模型本身，用 PaddleScience 代码表示如下
 
-``` py linenums="36"
+``` py linenums="24"
 --8<--
-examples/euler_beam/euler_beam.py:36:37
+examples/euler_beam/euler_beam.py:24:25
 --8<--
 ```
 
 其中，用于初始化模型的参数通过配置文件进行配置：
 
-``` yaml linenums="34"
+``` yaml linenums="38"
 --8<--
-examples/euler_beam/conf/euler_beam.yaml:34:38
+examples/euler_beam/conf/euler_beam.yaml:38:43
 --8<--
 ```
 
@@ -90,9 +90,9 @@ examples/euler_beam/conf/euler_beam.yaml:34:38
 
 Euler Beam 的方程构建可以直接使用 PaddleScience 内置的 `Biharmonic`，指定该类的参数 `dim` 为 1，`q` 为 -1，`D` 为1。
 
-``` py linenums="42"
+``` py linenums="30"
 --8<--
-examples/euler_beam/euler_beam.py:42:43
+examples/euler_beam/euler_beam.py:30:31
 --8<--
 ```
 
@@ -101,9 +101,9 @@ examples/euler_beam/euler_beam.py:42:43
 本文中 Euler Beam 问题作用在以 (0.0, 1.0) 的一维区域上，
 因此可以直接使用 PaddleScience 内置的空间几何 `Interval` 作为计算域。
 
-``` py linenums="39"
+``` py linenums="27"
 --8<--
-examples/euler_beam/euler_beam.py:39:40
+examples/euler_beam/euler_beam.py:27:28
 --8<--
 ```
 
@@ -113,9 +113,9 @@ examples/euler_beam/euler_beam.py:39:40
 
 在定义约束之前，需要给每一种约束指定采样点个数，表示每一种约束在其对应计算域内采样数据的数量，以及通用的采样配置。
 
-``` yaml linenums="49"
+``` yaml linenums="45"
 --8<--
-examples/euler_beam/conf/euler_beam.yaml:49:50
+examples/euler_beam/conf/euler_beam.yaml:45:55
 --8<--
 ```
 
@@ -123,9 +123,9 @@ examples/euler_beam/conf/euler_beam.yaml:49:50
 
 以作用在内部点上的 `InteriorConstraint` 为例，代码如下：
 
-``` py linenums="51"
+``` py linenums="33"
 --8<--
-examples/euler_beam/euler_beam.py:51:59
+examples/euler_beam/euler_beam.py:33:47
 --8<--
 ```
 
@@ -133,9 +133,9 @@ examples/euler_beam/euler_beam.py:51:59
 
 同理，我们还需要构建边界的约束。但与构建 `InteriorConstraint` 约束不同的是，由于作用区域是边界，因此我们使用 `BoundaryConstraint` 类，代码如下：
 
-``` py linenums="60"
+``` py linenums="48"
 --8<--
-examples/euler_beam/euler_beam.py:60:73
+examples/euler_beam/euler_beam.py:48:61
 --8<--
 ```
 
@@ -143,9 +143,9 @@ examples/euler_beam/euler_beam.py:60:73
 
 接下来我们需要在配置文件中指定训练轮数，此处我们按实验经验，使用一万轮训练轮数，评估间隔为一千轮。
 
-``` yaml linenums="41"
+``` yaml linenums="45"
 --8<--
-examples/euler_beam/conf/euler_beam.yaml:41:52
+examples/euler_beam/conf/euler_beam.yaml:45:51
 --8<--
 ```
 
@@ -153,9 +153,9 @@ examples/euler_beam/conf/euler_beam.yaml:41:52
 
 训练过程会调用优化器来更新模型参数，此处选择较为常用的 `Adam` 优化器。
 
-``` py linenums="80"
+``` py linenums="68"
 --8<--
-examples/euler_beam/euler_beam.py:80:81
+examples/euler_beam/euler_beam.py:68:69
 --8<--
 ```
 
@@ -163,9 +163,9 @@ examples/euler_beam/euler_beam.py:80:81
 
 在训练过程中通常会按一定轮数间隔，用验证集（测试集）评估当前模型的训练情况，因此使用 `ppsci.validate.GeometryValidator` 构建评估器。
 
-``` py linenums="89"
+``` py linenums="77"
 --8<--
-examples/euler_beam/euler_beam.py:89:102
+examples/euler_beam/euler_beam.py:77:90
 --8<--
 ```
 
@@ -175,9 +175,9 @@ examples/euler_beam/euler_beam.py:89:102
 
 本文中的输出数据是一个曲线图，因此我们只需要将评估的输出数据保存成 **png** 文件即可。代码如下：
 
-``` py linenums="104"
+``` py linenums="92"
 --8<--
-examples/euler_beam/euler_beam.py:104:114
+examples/euler_beam/euler_beam.py:92:105
 --8<--
 ```
 
@@ -185,9 +185,9 @@ examples/euler_beam/euler_beam.py:104:114
 
 完成上述设置之后，只需要将上述实例化的对象按顺序传递给 `ppsci.solver.Solver`，然后启动训练、评估、可视化。
 
-``` py linenums="117"
+``` py linenums="107"
 --8<--
-examples/euler_beam/euler_beam.py:117:141
+examples/euler_beam/euler_beam.py:107:132
 --8<--
 ```
 

--- a/docs/zh/user_guide.md
+++ b/docs/zh/user_guide.md
@@ -366,9 +366,9 @@ PaddleScience 提供了多种推理配置组合，可通过命令行进行组合
 
 |  | Native | ONNX | TensorRT | MKLDNN |
 | :--- | :--- | :--- | :--- | :--- |
-| CPU | ✅ | ✅| - | ✅ |
-| GPU | ✅ | ✅ | ✅ | - |
-| XPU | TODO | - | - | - |
+| CPU | ✅ | ✅| / | ✅ |
+| GPU | ✅ | ✅ | ✅ | / |
+| XPU | TODO | / | / | / |
 
 接下来以 aneurysm 案例和 Linux x86_64 + TensorRT 8.6 GA + CUDA 11.6 软硬件环境为例，介绍如何使用不同的推理配置。
 
@@ -447,7 +447,7 @@ PaddleScience 提供了多种推理配置组合，可通过命令行进行组合
 
 === "使用 MKLDNN 推理"
 
-    MDLDNN 是英伟达推出的高性能推理引擎，适用于 CPU 推理加速，PaddleScience 支持了 MKLDNN 推理功能。
+    MKLDNN 是英伟达推出的高性能推理引擎，适用于 CPU 推理加速，PaddleScience 支持了 MKLDNN 推理功能。
 
     运行以下命令进行推理：
 

--- a/docs/zh/user_guide.md
+++ b/docs/zh/user_guide.md
@@ -561,124 +561,124 @@ solver.eval()
 
 ### 1.7 实验过程可视化
 
-#### 1.7.1 TensorBoardX
+=== "TensorBoardX"
 
-[TensorBoardX](https://github.com/lanpa/tensorboardX) 是基于 TensorBoard 编写可视化分析工具，以丰富的图表呈现训练参数变化趋势、数据样本、模型结构、PR曲线、ROC曲线、高维数据分布等。帮助用户清晰直观地理解深度学习模型训练过程及模型结构，进而实现高效的模型调优。
+    [TensorBoardX](https://github.com/lanpa/tensorboardX) 是基于 TensorBoard 编写可视化分析工具，以丰富的图表呈现训练参数变化趋势、数据样本、模型结构、PR曲线、ROC曲线、高维数据分布等。帮助用户清晰直观地理解深度学习模型训练过程及模型结构，进而实现高效的模型调优。
 
-PaddleScience 支持使用 TensorBoardX 记录训练过程中的基础实验数据，包括 train/eval loss，eval metric，learning rate 等基本信息，可按如下步骤使用该功能。
+    PaddleScience 支持使用 TensorBoardX 记录训练过程中的基础实验数据，包括 train/eval loss，eval metric，learning rate 等基本信息，可按如下步骤使用该功能。
 
-1. 安装 Tensorboard 和 TensorBoardX
+    1. 安装 Tensorboard 和 TensorBoardX
 
-    ``` sh
-    pip install tensorboard tensorboardX
-    ```
+        ``` sh
+        pip install tensorboard tensorboardX
+        ```
 
-2. 在案例代码的 `Solver` 实例化时指定 `use_tbd=True`，然后再启动案例训练
+    2. 在案例代码的 `Solver` 实例化时指定 `use_tbd=True`，然后再启动案例训练
 
-    ``` py hl_lines="3"
-    solver = ppsci.solver.Solver(
-        ...,
-        use_tbd=True,
-    )
-    ```
+        ``` py hl_lines="3"
+        solver = ppsci.solver.Solver(
+            ...,
+            use_tbd=True,
+        )
+        ```
 
-3. 可视化记录数据
+    3. 可视化记录数据
 
-    根据上述步骤，在训练时 TensorBoardX 会自动记录数据并保存到 `${solver.output_dir}/tensorboard` 目录下，具体所在路径在实例化 `Solver` 时，会自动打印在终端中，如下所示。
+        根据上述步骤，在训练时 TensorBoardX 会自动记录数据并保存到 `${solver.output_dir}/tensorboard` 目录下，具体所在路径在实例化 `Solver` 时，会自动打印在终端中，如下所示。
 
-    ``` log hl_lines="3" hl_lines="2"
-    ppsci MESSAGE: TensorboardX tool is enabled for logging, you can view it by running:
-    tensorboard --logdir outputs_VIV/2024-01-01/08-00-00/tensorboard
-    ```
+        ``` log hl_lines="3" hl_lines="2"
+        ppsci MESSAGE: TensorboardX tool is enabled for logging, you can view it by running:
+        tensorboard --logdir outputs_VIV/2024-01-01/08-00-00/tensorboard
+        ```
 
-    !!! tip
+        !!! tip
 
-        也可以输入 `tensorboard --logdir ./outputs_VIV`，一次性在网页上展示 `outputs_VIV` 目录下所有训练记录，便于对比。
+            也可以输入 `tensorboard --logdir ./outputs_VIV`，一次性在网页上展示 `outputs_VIV` 目录下所有训练记录，便于对比。
 
-    在终端里输入上述可视化命令，并用浏览器进入 TensorBoardX 给出的可视化地址，即可在浏览器内查看记录的数据，如下图所示。
+        在终端里输入上述可视化命令，并用浏览器进入 TensorBoardX 给出的可视化地址，即可在浏览器内查看记录的数据，如下图所示。
 
-    ![tensorboardx_preview](https://paddle-org.bj.bcebos.com/paddlescience/docs/user_guide/tensorboardx_preview.JPG)
+        ![tensorboardx_preview](https://paddle-org.bj.bcebos.com/paddlescience/docs/user_guide/tensorboardx_preview.JPG)
 
-#### 1.7.2 VisualDL
+=== "VisualDL"
 
-[VisualDL](https://www.paddlepaddle.org.cn/paddle/visualdl) 是飞桨推出的可视化分析工具，以丰富的图表呈现训练参数变化趋势、数据样本、模型结构、PR曲线、ROC曲线、高维数据分布等。帮助用户清晰直观地理解深度学习模型训练过程及模型结构，进而实现高效的模型调优。
+    [VisualDL](https://www.paddlepaddle.org.cn/paddle/visualdl) 是飞桨推出的可视化分析工具，以丰富的图表呈现训练参数变化趋势、数据样本、模型结构、PR曲线、ROC曲线、高维数据分布等。帮助用户清晰直观地理解深度学习模型训练过程及模型结构，进而实现高效的模型调优。
 
-PaddleScience 支持使用 VisualDL 记录训练过程中的基础实验数据，包括 train/eval loss，eval metric，learning rate 等基本信息，可按如下步骤使用该功能。
+    PaddleScience 支持使用 VisualDL 记录训练过程中的基础实验数据，包括 train/eval loss，eval metric，learning rate 等基本信息，可按如下步骤使用该功能。
 
-1. 安装 VisualDL
+    1. 安装 VisualDL
 
-    ``` sh
-    pip install -U visualdl
-    ```
+        ``` sh
+        pip install -U visualdl
+        ```
 
-2. 在案例代码的 `Solver` 实例化时指定 `use_vdl=True`，然后再启动案例训练
+    2. 在案例代码的 `Solver` 实例化时指定 `use_vdl=True`，然后再启动案例训练
 
-    ``` py hl_lines="3"
-    solver = ppsci.solver.Solver(
-        ...,
-        use_vdl=True,
-    )
-    ```
+        ``` py hl_lines="3"
+        solver = ppsci.solver.Solver(
+            ...,
+            use_vdl=True,
+        )
+        ```
 
-3. 可视化记录数据
+    3. 可视化记录数据
 
-    根据上述步骤，在训练时 VisualDL 会自动记录数据并保存到 `${solver.output_dir}/vdl` 目录下，具体所在路径在实例化 `Solver` 时，会自动打印在终端中，如下所示。
+        根据上述步骤，在训练时 VisualDL 会自动记录数据并保存到 `${solver.output_dir}/vdl` 目录下，具体所在路径在实例化 `Solver` 时，会自动打印在终端中，如下所示。
 
-    ``` log hl_lines="4"
-    Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 11.8, Runtime API Version: 11.6
-    device: 0, cuDNN Version: 8.4.
-    ppsci INFO: VisualDL tool enabled for logging, you can view it by running:
-    visualdl --logdir outputs_darcy2d/2023-10-08/10-00-00/TRAIN.epochs=400/vdl --port 8080
-    ```
+        ``` log hl_lines="4"
+        Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 11.8, Runtime API Version: 11.6
+        device: 0, cuDNN Version: 8.4.
+        ppsci INFO: VisualDL tool enabled for logging, you can view it by running:
+        visualdl --logdir outputs_darcy2d/2023-10-08/10-00-00/TRAIN.epochs=400/vdl --port 8080
+        ```
 
-    在终端里输入上述可视化命令，并用浏览器进入 VisualDL 给出的可视化地址，即可在浏览器内查看记录的数据，如下图所示。
+        在终端里输入上述可视化命令，并用浏览器进入 VisualDL 给出的可视化地址，即可在浏览器内查看记录的数据，如下图所示。
 
-    ![visualdl_record](https://paddle-org.bj.bcebos.com/paddlescience/docs/user_guide/VisualDL_preview.png)
+        ![visualdl_record](https://paddle-org.bj.bcebos.com/paddlescience/docs/user_guide/VisualDL_preview.png)
 
-#### 1.7.3 WandB
+=== "WandB"
 
-[WandB](https://wandb.ai/) 是一个第三方实验记录工具，能在记录实验数据的同时将数据上传到其用户的私人账户上，防止实验记录丢失。
+    [WandB](https://wandb.ai/) 是一个第三方实验记录工具，能在记录实验数据的同时将数据上传到用户的私人账户上，防止实验记录丢失。
 
-PaddleScience 支持使用 WandB 记录基本的实验数据，包括 train/eval loss，eval metric，learning rate 等基本信息，可按如下步骤使用该功能
+    PaddleScience 支持使用 WandB 记录基本的实验数据，包括 train/eval loss，eval metric，learning rate 等基本信息，可按如下步骤使用该功能
 
-1. 安装 wandb
+    1. 安装 wandb
 
-    ``` sh
-    pip install wandb
-    ```
+        ``` sh
+        pip install wandb
+        ```
 
-2. 注册 wandb 并在终端登录
+    2. 注册 wandb 并在终端登录
 
-    ``` sh
-    # 登录 wandb 获取 API key
-    wandb login
-    # 根据 login 提示，输入 API key 并回车确认
-    ```
+        ``` sh
+        # 登录 wandb 获取 API key
+        wandb login
+        # 根据 login 提示，输入 API key 并回车确认
+        ```
 
-3. 在案例中开启 wandb
+    3. 在案例中开启 wandb
 
-    ``` py hl_lines="3 4 5 6 7 8"
-    solver = ppsci.solver.Solver(
-        ...,
-        use_wandb=True,
-        wandb_config={
-            "project": "PaddleScience",
-            "name": "Laplace2D",
-            "dir": OUTPUT_DIR,
-        },
-        ...
-    )
-    solver.train()
-    ```
+        ``` py hl_lines="3 4 5 6 7 8"
+        solver = ppsci.solver.Solver(
+            ...,
+            use_wandb=True,
+            wandb_config={
+                "project": "PaddleScience",
+                "name": "Laplace2D",
+                "dir": OUTPUT_DIR,
+            },
+            ...
+        )
+        solver.train()
+        ```
 
-    如上述代码所示，指定 `use_wandb=True`，并且设置 `wandb_config` 配置字典中的 `project`、`name`、`dir` 三个字段，然后启动训练即可。训练过程会实时上传记录数据至 wandb 服务器，训练结束后可以进入终端打印的预览地址在网页端查看完整训练记录曲线。
+        如上述代码所示，指定 `use_wandb=True`，并且设置 `wandb_config` 配置字典中的 `project`、`name`、`dir` 三个字段，然后启动训练即可。训练过程会实时上传记录数据至 wandb 服务器，训练结束后可以进入终端打印的预览地址在网页端查看完整训练记录曲线。
 
-    !!! warning "注意"
+        !!! warning "注意"
 
-        由于每次调用 `wandb.log` 会使得其自带的计数器 `Step` 自增 1，因此在 wandb 的网站上查看训练记录时，需要手动更改 x 轴的单位为 `step`(全小写)，如下所示。
+            由于每次调用 `wandb.log` 会使得其自带的计数器 `Step` 自增 1，因此在 wandb 的网站上查看训练记录时，需要手动更改 x 轴的单位为 `step`(全小写)，如下所示。
 
-        否则默认单位为 wandb 自带的 `Step` (S大写) 字段，会导致显示步数比实际步数多几倍。
-        ![wandb_step settings](../images/overview/wandb_step.JPG)
+            否则默认单位为 wandb 自带的 `Step` (S大写) 字段，会导致显示步数比实际步数多几倍。
+            ![wandb_step settings](../images/overview/wandb_step.JPG)
 
 ## 2. 进阶功能
 

--- a/examples/euler_beam/conf/euler_beam.yaml
+++ b/examples/euler_beam/conf/euler_beam.yaml
@@ -16,6 +16,9 @@ hydra:
           - mode
           - output_dir
           - log_freq
+  callbacks:
+    init_callback:
+      _target_: ppsci.utils.callbacks.InitCallback
   sweep:
     # output directory for multirun
     dir: ${hydra.run.dir}

--- a/examples/euler_beam/euler_beam.py
+++ b/examples/euler_beam/euler_beam.py
@@ -12,27 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import path as osp
-
 import hydra
-import paddle
 from omegaconf import DictConfig
 
 import ppsci
 from ppsci.autodiff import hessian
 from ppsci.autodiff import jacobian
-from ppsci.utils import logger
 
 
 def train(cfg: DictConfig):
-    # enable computation for fourth-order differentiation of matmul
-    paddle.framework.core.set_prim_eager_enabled(True)
-    paddle.framework.core._set_prim_all_enabled(True)
-    # set random seed for reproducibility
-    ppsci.utils.misc.set_random_seed(cfg.seed)
-    # initialize logger
-    logger.init_logger("ppsci", osp.join(cfg.output_dir, "train.log"), "info")
-
     # set model
     model = ppsci.arch.MLP(**cfg.MODEL)
 
@@ -145,14 +133,6 @@ def train(cfg: DictConfig):
 
 
 def evaluate(cfg: DictConfig):
-    # enable computation for fourth-order differentiation of matmul
-    paddle.framework.core.set_prim_eager_enabled(True)
-    paddle.framework.core._set_prim_all_enabled(True)
-    # set random seed for reproducibility
-    ppsci.utils.misc.set_random_seed(cfg.seed)
-    # initialize logger
-    logger.init_logger("ppsci", osp.join(cfg.output_dir, "eval.log"), "info")
-
     # set model
     model = ppsci.arch.MLP(**cfg.MODEL)
 

--- a/ppsci/equation/pde/base.py
+++ b/ppsci/equation/pde/base.py
@@ -129,6 +129,7 @@ class PDE:
 
         Returns:
             Tuple[List[str], List[str]]: List of missing_keys and unexpected_keys.
+                Expected to be two empty tuples mostly.
 
         Examples:
             >>> import paddle
@@ -138,6 +139,7 @@ class PDE:
             >>> state = pde.state_dict()
             >>> state['0'] = paddle.to_tensor(-3.1)
             >>> pde.set_state_dict(state)
+            ([], [])
             >>> print(state)
             OrderedDict([('0', Tensor(shape=[], dtype=float64, place=Place(gpu:0), stop_gradient=True,
                    -3.10000000)), ('1', Parameter containing:

--- a/ppsci/loss/mtl/sum.py
+++ b/ppsci/loss/mtl/sum.py
@@ -43,8 +43,8 @@ class Sum(LossAggregator):
         ), f"Number of given losses({len(losses)}) can not be empty."
         self.step = step
 
-        loss = 0.0
-        for i in range(len(losses)):
+        loss = losses[0]
+        for i in range(1, len(losses)):
             loss += losses[i]
 
         return loss


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs 
### Describe
<!-- Describe what this PR does -->
1. 修复使用文档中 MKLDNN 的拼写错误；
2. 合并tensorboard、visualdl、wandb使用教程为一个章节；
3. 将`Sum`的求和行为进行微调，并更改euler_beam的随机种子为42，使得收敛精度不低于原本的精度(8e-4-->0.00058)；
4. 由于现有paddle已支持eulerbeam在非组合模式下运行，因此删除euler_beam的组合开关。