### PR TITLE
[Enh] Support enabling prim via CLI

### DIFF
--- a/ppsci/utils/callbacks.py
+++ b/ppsci/utils/callbacks.py
@@ -97,3 +97,12 @@ class InitCallback(Callback):
             else None,
             full_cfg.log_level,
         )
+
+        # enable prim if specified
+        if "prim" in full_cfg and bool(full_cfg.prim):
+            # Mostly for dy2st running, will be removed in the future
+            from paddle.framework import core
+
+            core.set_prim_eager_enabled(True)
+            core._set_prim_all_enabled(True)
+            logger.message("Prim mode is enabled.")

--- a/ppsci/utils/config.py
+++ b/ppsci/utils/config.py
@@ -219,6 +219,7 @@ if importlib.util.find_spec("pydantic") is not None:
         use_amp: bool = False
         amp_level: Literal["O0", "O1", "O2", "OD"] = "O1"
         to_static: bool = False
+        prim: bool = False
         log_level: Literal["debug", "info", "warning", "error"] = "info"
 
         # Training related config


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
1. 支持以命令行的方式开启组合算子模式：`python xxx.py +prim=True`