### PR TITLE
[Fix] Check return type of FunctionalLoss

### DIFF
--- a/test/loss/func.py
+++ b/test/loss/func.py
@@ -1,0 +1,30 @@
+import paddle
+import pytest
+
+from ppsci import loss
+
+__all__ = []
+
+
+def test_non_tensor_return_type():
+    """Test for biharmonic equation."""
+
+    def loss_func_return_tensor(input_dict, label_dict, weight_dict):
+        return (0.5 * (input_dict["x"] - label_dict["x"]) ** 2).sum()
+
+    def loss_func_reuturn_builtin_float(input_dict, label_dict, weight_dict):
+        return (0.5 * (input_dict["x"] - label_dict["x"]) ** 2).sum().item()
+
+    wrapped_loss1 = loss.FunctionalLoss(loss_func_return_tensor)
+    wrapped_loss2 = loss.FunctionalLoss(loss_func_reuturn_builtin_float)
+
+    input_dict = {"x": paddle.randn([10, 1])}
+    label_dict = {"x": paddle.zeros([10, 1])}
+
+    wrapped_loss1(input_dict, label_dict)
+    with pytest.raises(AssertionError):
+        wrapped_loss2(input_dict, label_dict)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 对`FunctionalLoss`所包装的函数的返回值进行检查，确保其类型为张量。