### PR TITLE
[Fea] Support detach_keys argument for all PDE

### DIFF
--- a/ppsci/equation/pde/biharmonic.py
+++ b/ppsci/equation/pde/biharmonic.py
@@ -70,3 +70,5 @@ class Biharmonic(base.PDE):
                 biharmonic += u.diff(invar_i, 2).diff(invar_j, 2)
 
         self.add_equation("biharmonic", biharmonic)
+
+        self._apply_detach()

--- a/ppsci/equation/pde/heat_exchanger.py
+++ b/ppsci/equation/pde/heat_exchanger.py
@@ -90,3 +90,5 @@ class HeatExchanger(base.PDE):
         self.add_equation("heat_boundary", heat_boundary)
         self.add_equation("cold_boundary", cold_boundary)
         self.add_equation("wall", wall)
+
+        self._apply_detach()

--- a/ppsci/equation/pde/laplace.py
+++ b/ppsci/equation/pde/laplace.py
@@ -51,3 +51,5 @@ class Laplace(base.PDE):
             laplace += u.diff(invar, 2)
 
         self.add_equation("laplace", laplace)
+
+        self._apply_detach()

--- a/ppsci/equation/pde/linear_elasticity.py
+++ b/ppsci/equation/pde/linear_elasticity.py
@@ -179,3 +179,5 @@ class LinearElasticity(base.PDE):
         self.add_equation("traction_y", traction_y)
         if self.dim == 3:
             self.add_equation("traction_z", traction_z)
+
+        self._apply_detach()

--- a/ppsci/equation/pde/navier_stokes.py
+++ b/ppsci/equation/pde/navier_stokes.py
@@ -147,3 +147,5 @@ class NavierStokes(base.PDE):
         self.add_equation("momentum_y", momentum_y)
         if self.dim == 3:
             self.add_equation("momentum_z", momentum_z)
+
+        self._apply_detach()

--- a/ppsci/equation/pde/nls_m_b.py
+++ b/ppsci/equation/pde/nls_m_b.py
@@ -97,3 +97,5 @@ class NLSMB(base.PDE):
         self.add_equation("Maxwell_1", Maxwell_1)
         self.add_equation("Maxwell_2", Maxwell_2)
         self.add_equation("Bloch", Bloch)
+
+        self._apply_detach()

--- a/ppsci/equation/pde/normal_dot_vec.py
+++ b/ppsci/equation/pde/normal_dot_vec.py
@@ -55,3 +55,5 @@ class NormalDotVec(base.PDE):
             normal_dot_vec += normal * vec
 
         self.add_equation("normal_dot_vec", normal_dot_vec)
+
+        self._apply_detach()

--- a/ppsci/equation/pde/poisson.py
+++ b/ppsci/equation/pde/poisson.py
@@ -49,3 +49,5 @@ class Poisson(base.PDE):
             poisson += p.diff(invar, 2)
 
         self.add_equation("poisson", poisson)
+
+        self._apply_detach()

--- a/ppsci/equation/pde/viv.py
+++ b/ppsci/equation/pde/viv.py
@@ -60,3 +60,5 @@ class Vibration(base.PDE):
         k2 = self.create_symbols(self.k2.name)
         f = self.rho * eta.diff(t_f, 2) + sp.exp(k1) * eta.diff(t_f) + sp.exp(k2) * eta
         self.add_equation("f", f)
+
+        self._apply_detach()

--- a/ppsci/utils/symbolic.py
+++ b/ppsci/utils/symbolic.py
@@ -123,7 +123,10 @@ def _cvt_to_key(expr: sp.Basic) -> str:
     if isinstance(expr, (sp.Symbol, sp.core.function.UndefinedFunction, sp.Function)):
         # use name of custom function(e.g. "f") instead of itself(e.g. "f(x, y)")
         # for simplicity.
-        return str(expr.func)
+        if hasattr(expr, "name"):
+            return expr.name
+        else:
+            return str(expr)
     elif isinstance(expr, sp.Derivative):
         # convert "Derivative(u(x,y),(x,2),(y,2))" to "u__x__x__y__y"
         expr_str = expr.args[0].name
@@ -928,7 +931,7 @@ def lambdify(
             logger.debug(
                 f"Fused {len(candidate_pos)} derivatives nodes: "
                 f"{[callable_nodes_group[i][j].expr for i, j in candidate_pos]} into"
-                f" fuse node sequence: {fused_node_seq} at position: ([{gid0}][{nid0}])"
+                f" {len(fused_node_seq)} fuse node sequence: {fused_node_seq} at position: ([{gid0}][{nid0}])"
             )
 
             # mark merged node

--- a/ppsci/utils/symbolic.py
+++ b/ppsci/utils/symbolic.py
@@ -40,6 +40,7 @@ from ppsci.utils import logger
 
 __all__ = [
     "lambdify",
+    "_cvt_to_key",
 ]
 
 
@@ -116,6 +117,9 @@ def _cvt_to_key(expr: sp.Basic) -> str:
     Returns:
         str: Converted string key.
     """
+    if isinstance(expr, sp.Function) and expr.name == equation.DETACH_FUNC_NAME:
+        return f"{_cvt_to_key(expr.args[0])}_{equation.DETACH_FUNC_NAME}"
+
     if isinstance(expr, (sp.Symbol, sp.core.function.UndefinedFunction, sp.Function)):
         if hasattr(expr, "name"):
             # use name of custom function instead of itself.
@@ -815,6 +819,7 @@ def lambdify(
             elif isinstance(node, sp.Function):
                 if node.name == equation.DETACH_FUNC_NAME:
                     callable_nodes.append(DetachNode(node))
+                    logger.debug(f"Detected detach node {node}")
                 else:
                     match_index = None
                     for j, model in enumerate(models):

--- a/test/equation/test_detach.py
+++ b/test/equation/test_detach.py
@@ -1,0 +1,173 @@
+import numpy as np
+import paddle
+
+import ppsci
+from ppsci import arch
+from ppsci import equation
+
+
+def test_equation_detach():
+    # use N-S equation for test
+    all_items = [
+        "u",
+        "u__x",
+        "u__y",
+        "u__x__x",
+        "v",
+        "v__x",
+        "v__y",
+        "v__x__x",
+        "p",
+        "p__x",
+        "p__y",
+    ]
+    model1 = arch.MLP(("x", "y"), ("u", "v", "p"), 3, 16)
+    model2 = arch.MLP(("x", "y"), ("u", "v", "p"), 3, 16)
+    input_data = {
+        "x": paddle.randn([16, 1]),
+        "y": paddle.randn([16, 1]),
+    }
+    input_data["x"].stop_gradient = False
+    input_data["y"].stop_gradient = False
+    for ii, in_state in enumerate(range(0, 1 << len(all_items), 5)):
+        detach_keys = [
+            item for i, item in enumerate(all_items) if ((1 << i) & in_state)
+        ]
+        nu = 3.14
+        rho = 0.817
+        ns = equation.NavierStokes(nu, rho, 2, False, detach_keys=detach_keys)
+        model2.set_state_dict(model1.state_dict())
+
+        exprs = ppsci.lambdify(
+            list(ns.equations.values()),
+            model1,
+            fuse_derivative=False,
+        )
+        for name, f in zip(ns.equations, exprs):
+            input_data[name] = f(input_data)
+
+        def compute_loss(data_dict):
+            u = data_dict["u"]
+            v = data_dict["v"]
+            p = data_dict["p"]
+
+            u__x = data_dict["u__x"]
+            u__y = data_dict["u__y"]
+            u__x__x = data_dict["u__x__x"]
+            u__y__y = data_dict["u__y__y"]
+
+            v = data_dict["v"]
+            v__x = data_dict["v__x"]
+            v__y = data_dict["v__y"]
+            v__x__x = data_dict["v__x__x"]
+            v__y__y = data_dict["v__y__y"]
+
+            p = data_dict["p"]
+            p__x = data_dict["p__x"]
+            p__y = data_dict["p__y"]
+
+            if "u" in detach_keys:
+                u = u.detach()
+            if "v" in detach_keys:
+                v = v.detach()
+            if "p" in detach_keys:
+                p = p.detach()
+            if "u__x" in detach_keys:
+                u__x = u__x.detach()
+            if "u__y" in detach_keys:
+                u__y = u__y.detach()
+            if "u__x__x" in detach_keys:
+                u__x__x = u__x__x.detach()
+            if "u__y__y" in detach_keys:
+                u__y__y = u__y__y.detach()
+            if "v__x" in detach_keys:
+                v__x = v__x.detach()
+            if "v__y" in detach_keys:
+                v__y = v__y.detach()
+            if "v__x__x" in detach_keys:
+                v__x__x = v__x__x.detach()
+            if "v__y__y" in detach_keys:
+                v__y__y = v__y__y.detach()
+            if "p__x" in detach_keys:
+                p__x = p__x.detach()
+            if "p__y" in detach_keys:
+                p__y = p__y.detach()
+
+            # continuity
+            continuity = u__x + v__y
+            # momentum_x
+            momentum_x = (
+                u * u__x + v * u__y - nu * (u__x__x + u__y__y) + (1 / rho) * p__x
+            )
+            # momentum_y
+            momentum_y = (
+                u * v__x + v * v__y - nu * (v__x__x + v__y__y) + (1 / rho) * p__y
+            )
+
+            return (
+                (continuity**2).sum()
+                + (momentum_x**2).sum()
+                + (momentum_y**2).sum()
+            )
+
+        loss1 = compute_loss(input_data)
+
+        loss1.backward()
+
+        ppsci.autodiff.clear()
+
+        input_data = {
+            "x": input_data["x"],
+            "y": input_data["y"],
+        }
+        x, y = input_data["x"], input_data["y"]
+        t = model2(input_data)
+        u, v, p = t["u"], t["v"], t["p"]
+
+        u__x = ppsci.autodiff.jacobian(u, x)
+        u__y = ppsci.autodiff.jacobian(u, y)
+        u__x__x = ppsci.autodiff.hessian(u, x)
+        u__y__y = ppsci.autodiff.hessian(u, y)
+
+        v__x = ppsci.autodiff.jacobian(v, x)
+        v__y = ppsci.autodiff.jacobian(v, y)
+        v__x__x = ppsci.autodiff.hessian(v, x)
+        v__y__y = ppsci.autodiff.hessian(v, y)
+
+        p__x = ppsci.autodiff.jacobian(p, x)
+        p__y = ppsci.autodiff.jacobian(p, y)
+
+        loss2 = compute_loss(
+            {
+                "u": u,
+                "v": v,
+                "p": p,
+                "u__x": u__x,
+                "u__y": u__y,
+                "u__x__x": u__x__x,
+                "u__y__y": u__y__y,
+                "v__x": v__x,
+                "v__y": v__y,
+                "v__x__x": v__x__x,
+                "v__y__y": v__y__y,
+                "p__x": p__x,
+                "p__y": p__y,
+            }
+        )
+        loss2.backward()
+
+        np.testing.assert_allclose(loss1.numpy(), loss2.numpy())
+
+        for p1, p2 in zip(model1.parameters(), model2.parameters()):
+            if (p1.grad is None) ^ (p2.grad is None):
+                raise AssertionError()
+            if p1.grad is not None and p2.grad is not None:
+                np.testing.assert_allclose(p1.grad.numpy(), p2.grad.numpy())
+
+        ppsci.autodiff.clear()
+        model1.clear_gradients()
+        model2.clear_gradients()
+
+
+if __name__ == "__main__":
+    test_equation_detach()

--- a/test/equation/test_pde_base.py
+++ b/test/equation/test_pde_base.py
@@ -129,7 +129,7 @@ class Test_PDE:
 
         pde.add_equation("simple", simple_equation)
 
-        assert str(pde).startswith("PDE, simple: ")
+        assert str(pde).startswith("PDE\n    simple: ")
 
 
 if __name__ == "__main__":

--- a/test/utils/test_symbolic.py
+++ b/test/utils/test_symbolic.py
@@ -85,10 +85,13 @@ def test_multi_model_and_sdf():
     tmp2_eval = ep_eval * tmp1_eval * k_eval
     out_var_reference = tmp1_eval + tmp2_eval
 
-    assert np.allclose(out_var_tensor.numpy(), out_var_reference.numpy())
+    np.testing.assert_allclose(
+        out_var_tensor.numpy(), out_var_reference.numpy(), 1e-6, 0.0
+    )
 
 
 def test_complicated_symbolic():
+    paddle.seed(2023)
     x_ten = paddle.randn([32, 1])
     x_ten.stop_gradient = False
     y_ten = paddle.randn([32, 1])
@@ -136,13 +139,13 @@ def test_complicated_symbolic():
         eqs_expected = ppsci.lambdify(
             targets,
             model_f,
-            fuse_derivative=True,
+            fuse_derivative=False,
         )
 
         for i in range(len(targets)):
             output_fuse = eqs_fuse[i](input_data)
             output_expected = eqs_expected[i](input_data)
-            assert np.allclose(output_fuse.numpy(), output_expected.numpy())
+            np.testing.assert_allclose(output_fuse.numpy(), output_expected.numpy())
         ppsci.autodiff.clear()
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 支持方程初始化时指定`detach_keys`，使得梯度不会通过这些key对应的变量反向传播，并添加对应单测。
    ```mermaid
    graph TD;
        x & y-->u & v;
        x & u-->u__x;
        y & v-->v__y;
        u__x & u --> o1;
        v__y & v --> o2;
        o1 & o2 --> z;
    ```
    
    当`detach_keys`为`("u", "v__y")`时，计算关系会变为下图（新增两条detach路径）。
    
    ```mermaid
    graph TD;
        x & y-->u & v;
        x & u-->u__x;
        y & v-->v__y;
        u --> |detach| u_detach([u_detach]);
        u__x & u_detach --> o1;
        v__y --> |detach| v__y_detach([v__y_detach]);
        v__y_detach & v --> o2;
        o1 & o2 --> z;
    ```