### PR TITLE
[Refine] Refine loss and metric module

### DIFF
--- a/examples/RegAE/RegAE.py
+++ b/examples/RegAE/RegAE.py
@@ -56,7 +56,10 @@ def train(cfg: DictConfig):
         base = paddle.exp(2.0 * log_sigma) + paddle.pow(mu, 2) - 1.0 - 2.0 * log_sigma
         KLLoss = 0.5 * paddle.sum(base) / mu.shape[0]
 
-        return F.mse_loss(output_dict["decoder_z"], label_dict["p_train"]) + KLLoss
+        return {
+            "decode_loss": F.mse_loss(output_dict["decoder_z"], label_dict["p_train"])
+            + KLLoss
+        }
 
     # set constraint
     sup_constraint = ppsci.constraint.SupervisedConstraint(

--- a/examples/allen_cahn/allen_cahn_piratenet.py
+++ b/examples/allen_cahn/allen_cahn_piratenet.py
@@ -65,7 +65,6 @@ def train(cfg: DictConfig):
 
     # set equation
     equation = {"AllenCahn": ppsci.equation.AllenCahn(eps=0.01)}
-    ppsci.utils.logger.info(equation["AllenCahn"])
 
     # set constraint
     data = sio.loadmat(cfg.DATA_PATH)

--- a/examples/allen_cahn/allen_cahn_piratenet.py
+++ b/examples/allen_cahn/allen_cahn_piratenet.py
@@ -65,6 +65,7 @@ def train(cfg: DictConfig):
 
     # set equation
     equation = {"AllenCahn": ppsci.equation.AllenCahn(eps=0.01)}
+    ppsci.utils.logger.info(equation["AllenCahn"])
 
     # set constraint
     data = sio.loadmat(cfg.DATA_PATH)

--- a/examples/amgnet/amgnet_airfoil.py
+++ b/examples/amgnet/amgnet_airfoil.py
@@ -37,7 +37,7 @@ def train_mse_func(
     label_dict: Dict[str, "pgl.Graph"],
     *args,
 ) -> paddle.Tensor:
-    return F.mse_loss(output_dict["pred"], label_dict["label"].y)
+    return {"pred": F.mse_loss(output_dict["pred"], label_dict["label"].y)}
 
 
 def eval_rmse_func(

--- a/examples/amgnet/amgnet_cylinder.py
+++ b/examples/amgnet/amgnet_cylinder.py
@@ -37,7 +37,7 @@ def train_mse_func(
     label_dict: Dict[str, "pgl.Graph"],
     *args,
 ) -> paddle.Tensor:
-    return F.mse_loss(output_dict["pred"], label_dict["label"].y)
+    return {"pred": F.mse_loss(output_dict["pred"], label_dict["label"].y)}
 
 
 def eval_rmse_func(

--- a/examples/cfdgcn/cfdgcn.py
+++ b/examples/cfdgcn/cfdgcn.py
@@ -33,7 +33,7 @@ def train_mse_func(
     label_dict: Dict[str, "pgl.Graph"],
     *args,
 ) -> paddle.Tensor:
-    return F.mse_loss(output_dict["pred"], label_dict["label"].y)
+    return {"pred": F.mse_loss(output_dict["pred"], label_dict["label"].y)}
 
 
 def eval_rmse_func(

--- a/examples/deepcfd/deepcfd.py
+++ b/examples/deepcfd/deepcfd.py
@@ -243,7 +243,7 @@ def train(cfg: DictConfig):
         loss_v = (output[:, 1:2, :, :] - y[:, 1:2, :, :]) ** 2
         loss_p = (output[:, 2:3, :, :] - y[:, 2:3, :, :]).abs()
         loss = (loss_u + loss_v + loss_p) / CHANNELS_WEIGHTS
-        return loss.sum()
+        return {"output": loss.sum()}
 
     sup_constraint = ppsci.constraint.SupervisedConstraint(
         {

--- a/examples/deephpms/burgers.py
+++ b/examples/deephpms/burgers.py
@@ -31,7 +31,7 @@ from ppsci.utils import save_load
 
 def pde_loss_func(output_dict, *args):
     losses = F.mse_loss(output_dict["f_pde"], output_dict["du_t"], "sum")
-    return losses
+    return {"pde": losses}
 
 
 def pde_l2_rel_func(output_dict, *args):
@@ -53,7 +53,7 @@ def boundary_loss_func(output_dict, *args):
 
     losses = F.mse_loss(u_lb, u_ub, "sum")
     losses += F.mse_loss(du_x_lb, du_x_ub, "sum")
-    return losses
+    return {"boundary": losses}
 
 
 def train(cfg: DictConfig):

--- a/examples/deephpms/korteweg_de_vries.py
+++ b/examples/deephpms/korteweg_de_vries.py
@@ -31,7 +31,7 @@ from ppsci.utils import save_load
 
 def pde_loss_func(output_dict, *args):
     losses = F.mse_loss(output_dict["f_pde"], output_dict["du_t"], "sum")
-    return losses
+    return {"pde": losses}
 
 
 def pde_l2_rel_func(output_dict, *args):
@@ -56,7 +56,7 @@ def boundary_loss_func(output_dict, *args):
     losses = F.mse_loss(u_lb, u_ub, "sum")
     losses += F.mse_loss(du_x_lb, du_x_ub, "sum")
     losses += F.mse_loss(du_xx_lb, du_xx_ub, "sum")
-    return losses
+    return {"boundary": losses}
 
 
 def train(cfg: DictConfig):

--- a/examples/deephpms/kuramoto_sivashinsky.py
+++ b/examples/deephpms/kuramoto_sivashinsky.py
@@ -31,7 +31,7 @@ from ppsci.utils import save_load
 
 def pde_loss_func(output_dict, *args):
     losses = F.mse_loss(output_dict["f_pde"], output_dict["du_t"], "sum")
-    return losses
+    return {"pde": losses}
 
 
 def pde_l2_rel_func(output_dict, *args):
@@ -59,7 +59,7 @@ def boundary_loss_func(output_dict, *args):
     losses += F.mse_loss(du_x_lb, du_x_ub, "sum")
     losses += F.mse_loss(du_xx_lb, du_xx_ub, "sum")
     losses += F.mse_loss(du_xxx_lb, du_xxx_ub, "sum")
-    return losses
+    return {"boundary": losses}
 
 
 def train(cfg: DictConfig):

--- a/examples/deephpms/navier_stokes.py
+++ b/examples/deephpms/navier_stokes.py
@@ -31,7 +31,7 @@ from ppsci.utils import save_load
 
 def pde_loss_func(output_dict, *args):
     losses = F.mse_loss(output_dict["f_pde"], output_dict["dw_t"], "sum")
-    return losses
+    return {"pde": losses}
 
 
 def pde_l2_rel_func(output_dict, *args):

--- a/examples/deephpms/schrodinger.py
+++ b/examples/deephpms/schrodinger.py
@@ -32,7 +32,7 @@ from ppsci.utils import save_load
 def pde_loss_func(output_dict, *args):
     losses = F.mse_loss(output_dict["f_pde"], output_dict["du_t"], "sum")
     losses += F.mse_loss(output_dict["g_pde"], output_dict["dv_t"], "sum")
-    return losses
+    return {"pde": losses}
 
 
 def pde_l2_rel_func(output_dict, *args):
@@ -62,7 +62,7 @@ def boundary_loss_func(output_dict, *args):
     losses += F.mse_loss(v_lb, v_ub, "sum")
     losses += F.mse_loss(du_x_lb, du_x_ub, "sum")
     losses += F.mse_loss(dv_x_lb, dv_x_ub, "sum")
-    return losses
+    return {"boundary": losses}
 
 
 def sol_l2_rel_func(output_dict, label_dict):

--- a/examples/earthformer/enso_metric.py
+++ b/examples/earthformer/enso_metric.py
@@ -83,7 +83,9 @@ def train_mse_func(
     label_dict: Dict[str, "paddle.Tensor"],
     *args,
 ) -> paddle.Tensor:
-    return F.mse_loss(output_dict["sst_target"], label_dict["sst_target"])
+    return {
+        "sst_target": F.mse_loss(output_dict["sst_target"], label_dict["sst_target"])
+    }
 
 
 def eval_rmse_func(

--- a/examples/earthformer/sevir_metric.py
+++ b/examples/earthformer/sevir_metric.py
@@ -278,4 +278,4 @@ def train_mse_func(
     pred = output_dict["vil"]
     vil_target = label_dict["vil"]
     target = vil_target.reshape([-1, *vil_target.shape[2:]])
-    return F.mse_loss(pred, target)
+    return {"vil": F.mse_loss(pred, target)}

--- a/examples/epnn/functions.py
+++ b/examples/epnn/functions.py
@@ -128,7 +128,7 @@ def train_loss_func(output_dict, *args) -> paddle.Tensor:
     loss_log["state_elasto"].append(float(loss_elasto))
     loss_log["state_plastic"].append(float(loss_plastic))
     loss_log["stress"].append(float(loss_stress))
-    return loss
+    return {"train_loss": loss}
 
 
 def eval_loss_func(output_dict, *args) -> paddle.Tensor:
@@ -150,7 +150,7 @@ def eval_loss_func(output_dict, *args) -> paddle.Tensor:
     logger.message(
         f"error(total): {float(error)}, error(error_elasto): {float(error_elasto)}, error(error_plastic): {float(error_plastic)}, error(error_stress): {float(error_stress)}"
     )
-    return error
+    return {"eval_loss": error}
 
 
 def metric_expr(output_dict, *args) -> Dict[str, paddle.Tensor]:

--- a/examples/epnn/functions.py
+++ b/examples/epnn/functions.py
@@ -216,8 +216,8 @@ def loss_func(output_dict, criterion) -> paddle.Tensor:
     )
     target_stress = output_dict["stress_y"]
     loss_stress = criterion({"input": input_stress}, {"input": target_stress})
-    loss = loss_elasto + loss_plastic + loss_stress
-    return loss, loss_elasto, loss_plastic, loss_stress
+    loss = loss_elasto["input"] + loss_plastic["input"] + loss_stress["input"]
+    return loss, loss_elasto["input"], loss_plastic["input"], loss_stress["input"]
 
 
 class Dataset:

--- a/examples/epnn/functions.py
+++ b/examples/epnn/functions.py
@@ -106,9 +106,13 @@ gkratio = paddle.to_tensor(
 
 
 def val_loss_criterion(x, y):
-    return 100.0 * (
-        paddle.linalg.norm(x=x["input"] - y["input"]) / paddle.linalg.norm(x=y["input"])
-    )
+    return {
+        "input": 100.0
+        * (
+            paddle.linalg.norm(x=x["input"] - y["input"])
+            / paddle.linalg.norm(x=y["input"])
+        )
+    }
 
 
 def train_loss_func(output_dict, *args) -> paddle.Tensor:

--- a/examples/hpinns/functions.py
+++ b/examples/hpinns/functions.py
@@ -265,7 +265,7 @@ def pde_loss_fun(output_dict: Dict[str, paddle.Tensor], *args) -> paddle.Tensor:
     )
     loss_log.append(float(loss_eqs1 + loss_eqs2))  # for plotting
     loss_log.append(float(loss_lag1 + loss_lag2))  # for plotting
-    return losses
+    return {"pde": losses}
 
 
 def obj_loss_fun(output_dict: Dict[str, paddle.Tensor], *args) -> paddle.Tensor:
@@ -293,7 +293,7 @@ def obj_loss_fun(output_dict: Dict[str, paddle.Tensor], *args) -> paddle.Tensor:
     losses = loss_weight[4] * loss_opt_area
     loss_log.append(float(loss_opt_area))  # for plotting
     loss_obj = float(loss_opt_area)  # for plotting
-    return losses
+    return {"obj": losses}
 
 
 def eval_loss_fun(output_dict: Dict[str, paddle.Tensor], *args) -> paddle.Tensor:
@@ -314,7 +314,7 @@ def eval_loss_fun(output_dict: Dict[str, paddle.Tensor], *args) -> paddle.Tensor
     j = e_re**2 + e_im**2 - f1 * f2
     losses = paddle.mean(j**2)
 
-    return losses
+    return {"eval": losses}
 
 
 def eval_metric_fun(

--- a/examples/neuraloperator/metric.py
+++ b/examples/neuraloperator/metric.py
@@ -178,7 +178,7 @@ class LpLoss_train(LpLoss):
     ):
         x = output_dict["y"]
         y = label_dict["y"]
-        return self.rel(x, y)
+        return {"y": self.rel(x, y)}
 
 
 class H1Loss(object):
@@ -404,4 +404,4 @@ class H1Loss_train(H1Loss):
         x = output_dict["y"]
         y = label_dict["y"]
 
-        return self.rel(x, y, h=h)
+        return {"y": self.rel(x, y, h=h)}

--- a/examples/phycrnet/functions.py
+++ b/examples/phycrnet/functions.py
@@ -151,11 +151,11 @@ def train_loss_func(result_dict, *args) -> paddle.Tensor:
     Returns:
         paddle.Tensor: Loss value.
     """
-    return result_dict["loss"]
+    return {"residual": result_dict["loss"]}
 
 
 def val_loss_func(result_dict, *args) -> paddle.Tensor:
-    return result_dict["loss"]
+    return {"residual": result_dict["loss"]}
 
 
 def metric_expr(output_dict, *args) -> Dict[str, paddle.Tensor]:

--- a/examples/phygeonet/heat_equation.py
+++ b/examples/phygeonet/heat_equation.py
@@ -42,7 +42,9 @@ def train(cfg: DictConfig):
             "iters_per_epoch": iters_per_epoch,
             "num_workers": 0,
         },
-        ppsci.loss.FunctionalLoss(lambda out, label, weight: out["residual"]),
+        ppsci.loss.FunctionalLoss(
+            lambda out, label, weight: {"residual": out["residual"]}
+        ),
         name="residual",
     )
     sup_constraint = {sup_constraint_res.name: sup_constraint_res}

--- a/examples/phygeonet/heat_equation_with_bc.py
+++ b/examples/phygeonet/heat_equation_with_bc.py
@@ -42,7 +42,9 @@ def train(cfg: DictConfig):
             "iters_per_epoch": iters_per_epoch,
             "num_workers": 0,
         },
-        ppsci.loss.FunctionalLoss(lambda out, label, weight: out["residual"]),
+        ppsci.loss.FunctionalLoss(
+            lambda out, label, weight: {"residual": out["residual"]}
+        ),
         name="residual",
     )
     sup_constraint = {sup_constraint_res.name: sup_constraint_res}

--- a/examples/phylstm/functions.py
+++ b/examples/phylstm/functions.py
@@ -73,7 +73,7 @@ def train_loss_func2(result_dict, *args) -> paddle.Tensor:
     # total loss
     loss = loss_u + loss_udot + loss_ut_c + loss_e
     loss = paddle.square(loss)
-    return loss
+    return {"loss2": loss}
 
 
 def train_loss_func3(result_dict, *args) -> paddle.Tensor:
@@ -106,7 +106,7 @@ def train_loss_func3(result_dict, *args) -> paddle.Tensor:
 
     loss = loss_u + loss_udot + loss_ut_c + loss_gt_c + loss_e
     loss = paddle.square(loss)
-    return loss
+    return {"loss3": loss}
 
 
 class Dataset:

--- a/examples/tempoGAN/functions.py
+++ b/examples/tempoGAN/functions.py
@@ -323,7 +323,7 @@ class GenFuncs:
                 )
             losses += loss_layer * self.weight_gen_layer[0]
 
-        return losses
+        return {"output_gen": losses}
 
     def loss_func_gen_tempo(self, output_dict: Dict, *args) -> paddle.Tensor:
         """Calculate loss of generator when use temporal discriminator.
@@ -342,7 +342,7 @@ class GenFuncs:
             out_disc_tempo_from_gen, label_t_ones, reduction="mean"
         )
         losses = loss_gen_t * self.weight_gen[2]
-        return losses
+        return {"out_disc_tempo_from_gen": losses}
 
 
 class DiscFuncs:

--- a/examples/topopt/topopt.py
+++ b/examples/topopt/topopt.py
@@ -270,7 +270,7 @@ def loss_wrapper(cfg: DictConfig):
             nn.functional.log_loss(label_pred, label_true, epsilon=1.0e-7)
         )
         vol_loss = paddle.square(paddle.mean(label_true - label_pred))
-        return conf_loss + cfg.vol_coeff * vol_loss
+        return {"output": conf_loss + cfg.vol_coeff * vol_loss}
 
     return loss_expr
 

--- a/examples/xpinn/xpinn.py
+++ b/examples/xpinn/xpinn.py
@@ -188,7 +188,7 @@ def loss_fun(
         residual_func=residual_func,
     )
 
-    return loss1 + loss2 + loss3
+    return {"residuals": loss1 + loss2 + loss3}
 
 
 def eval_l2_rel_func(

--- a/ppsci/constraint/boundary_constraint.py
+++ b/ppsci/constraint/boundary_constraint.py
@@ -91,9 +91,6 @@ class BoundaryConstraint(base.Constraint):
         self.output_expr = {
             k: v for k, v in output_expr.items() if k in self.output_keys
         }
-        # "area" will be kept in "output_dict" for computation.
-        if isinstance(geom, geometry.Mesh):
-            self.output_keys += ("area",)
 
         if isinstance(criteria, str):
             criteria = eval(criteria)

--- a/ppsci/constraint/initial_constraint.py
+++ b/ppsci/constraint/initial_constraint.py
@@ -97,9 +97,6 @@ class InitialConstraint(base.Constraint):
         self.output_expr = {
             k: v for k, v in output_expr.items() if k in self.output_keys
         }
-        # "area" will be kept in "output_dict" for computation.
-        if isinstance(geom.geometry, geometry.Mesh):
-            self.output_keys += ("area",)
 
         if isinstance(criteria, str):
             criteria = eval(criteria)

--- a/ppsci/constraint/integral_constraint.py
+++ b/ppsci/constraint/integral_constraint.py
@@ -92,9 +92,6 @@ class IntegralConstraint(base.Constraint):
         self.output_expr = {
             k: v for k, v in output_expr.items() if k in self.output_keys
         }
-        # "area" will be kept in "output_dict" for computation.
-        if isinstance(geom, geometry.Mesh):
-            self.output_keys += ("area",)
 
         if isinstance(criteria, str):
             criteria = eval(criteria)

--- a/ppsci/constraint/interior_constraint.py
+++ b/ppsci/constraint/interior_constraint.py
@@ -94,9 +94,6 @@ class InteriorConstraint(base.Constraint):
         self.output_expr = {
             k: v for k, v in output_expr.items() if k in self.output_keys
         }
-        # "area" will be kept in "output_dict" for computation.
-        if isinstance(geom, geometry.Mesh):
-            self.output_keys += ("area",)
 
         if isinstance(criteria, str):
             criteria = eval(criteria)

--- a/ppsci/constraint/periodic_constraint.py
+++ b/ppsci/constraint/periodic_constraint.py
@@ -77,9 +77,6 @@ class PeriodicConstraint(base.Constraint):
         self.output_expr = {
             k: v for k, v in output_expr.items() if k in self.output_keys
         }
-        # "area" will be kept in "output_dict" for computation.
-        if isinstance(geom, geometry.Mesh):
-            self.output_keys += ("area",)
 
         if isinstance(criteria, str):
             criteria = eval(criteria)

--- a/ppsci/loss/chamfer.py
+++ b/ppsci/loss/chamfer.py
@@ -59,8 +59,11 @@ class ChamferLoss(base.Loss):
     ):
         super().__init__("mean", weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             s1 = output_dict[key]
             s2 = label_dict[key]
@@ -84,5 +87,6 @@ class ChamferLoss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses

--- a/ppsci/loss/chamfer.py
+++ b/ppsci/loss/chamfer.py
@@ -49,8 +49,8 @@ class ChamferLoss(base.Loss):
         >>> loss = ChamferLoss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               0.04415882)
+        {'s1': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.04415882)}
     """
 
     def __init__(

--- a/ppsci/loss/func.py
+++ b/ppsci/loss/func.py
@@ -76,6 +76,12 @@ class FunctionalLoss(base.Loss):
     ) -> Dict[str, "paddle.Tensor"]:
         losses = self.loss_expr(output_dict, label_dict, weight_dict)
 
+        assert isinstance(losses, dict), (
+            "Loss computed by custom function should be type of 'dict', "
+            f"but got {type(losses)}."
+            " Please check the return type of custom loss function."
+        )
+
         for key in losses:
             assert isinstance(
                 losses[key], (paddle.Tensor, paddle.static.Variable, paddle.pir.Value)

--- a/ppsci/loss/func.py
+++ b/ppsci/loss/func.py
@@ -71,15 +71,18 @@ class FunctionalLoss(base.Loss):
         super().__init__(None, weight)
         self.loss_expr = loss_expr
 
-    def forward(self, output_dict, label_dict=None, weight_dict=None) -> paddle.Tensor:
-        loss = self.loss_expr(output_dict, label_dict, weight_dict)
+    def forward(
+        self, output_dict, label_dict=None, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = self.loss_expr(output_dict, label_dict, weight_dict)
 
-        assert isinstance(
-            loss, (paddle.Tensor, paddle.static.Variable, paddle.pir.Value)
-        ), (
-            "Loss computed by custom function should be type of 'paddle.Tensor', "
-            f"'paddle.static.Variable' or 'paddle.pir.Value', but got {type(loss)}."
-            " Please check the return type of custom loss function."
-        )
+        for key in losses:
+            assert isinstance(
+                losses[key], (paddle.Tensor, paddle.static.Variable, paddle.pir.Value)
+            ), (
+                "Loss computed by custom function should be type of 'paddle.Tensor', "
+                f"'paddle.static.Variable' or 'paddle.pir.Value', but got {type(losses[key])}."
+                " Please check the return type of custom loss function."
+            )
 
-        return loss
+        return losses

--- a/ppsci/loss/func.py
+++ b/ppsci/loss/func.py
@@ -50,7 +50,7 @@ class FunctionalLoss(base.Loss):
         ...         if weight_dict:
         ...             loss *=  weight_dict[key]
         ...         losses += loss
-        ...     return losses
+        ...     return {"mse_loss": losses}
         >>> loss = FunctionalLoss(mse_sum_loss)
         >>> output_dict = {'u': paddle.to_tensor([[0.5, 0.9], [1.1, -1.3]]),
         ...             'v': paddle.to_tensor([[0.5, 0.9], [1.1, -1.3]])}
@@ -59,8 +59,8 @@ class FunctionalLoss(base.Loss):
         >>> weight_dict = {'u': 0.8, 'v': 0.2}
         >>> result = loss(output_dict, label_dict, weight_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               17.89600182)
+        {'mse_loss': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               17.89600182)}
     """
 
     def __init__(

--- a/ppsci/loss/integral.py
+++ b/ppsci/loss/integral.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import Optional
 from typing import Union
@@ -22,6 +23,9 @@ import paddle.nn.functional as F
 from typing_extensions import Literal
 
 from ppsci.loss import base
+
+if TYPE_CHECKING:
+    import paddle
 
 
 class IntegralLoss(base.Loss):
@@ -77,8 +81,11 @@ class IntegralLoss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             loss = F.mse_loss(
                 (output_dict[key] * output_dict["area"]).sum(axis=1),
@@ -98,5 +105,6 @@ class IntegralLoss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses

--- a/ppsci/loss/integral.py
+++ b/ppsci/loss/integral.py
@@ -60,14 +60,16 @@ class IntegralLoss(base.Loss):
         >>> loss = IntegralLoss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               1.40911996)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               1.40780795), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.00131200)}
 
         >>> loss = IntegralLoss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               2.81823993)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               2.81561589), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.00262400)}
     """
 
     def __init__(

--- a/ppsci/loss/kl.py
+++ b/ppsci/loss/kl.py
@@ -36,10 +36,16 @@ class KLLoss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict=None, weight_dict=None):
+    def forward(
+        self, output_dict, label_dict=None, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         mu, log_sigma = output_dict["mu"], output_dict["log_sigma"]
 
         base = paddle.exp(2.0 * log_sigma) + paddle.pow(mu, 2) - 1.0 - 2.0 * log_sigma
         loss = 0.5 * paddle.sum(base) / mu.shape[0]
+
+        losses["kl_loss"] = loss
 
         return loss

--- a/ppsci/loss/l1.py
+++ b/ppsci/loss/l1.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import Optional
 from typing import Union
@@ -22,6 +23,10 @@ import paddle.nn.functional as F
 from typing_extensions import Literal
 
 from ppsci.loss import base
+
+if TYPE_CHECKING:
+
+    import paddle
 
 
 class L1Loss(base.Loss):
@@ -83,8 +88,11 @@ class L1Loss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             loss = F.l1_loss(output_dict[key], label_dict[key], "none")
             if weight_dict and key in weight_dict:
@@ -105,7 +113,8 @@ class L1Loss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses
 
 
@@ -168,8 +177,11 @@ class PeriodicL1Loss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             n_output = len(output_dict[key])
             if n_output % 2 > 0:
@@ -198,5 +210,6 @@ class PeriodicL1Loss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses

--- a/ppsci/loss/l1.py
+++ b/ppsci/loss/l1.py
@@ -67,14 +67,16 @@ class L1Loss(base.Loss):
         >>> loss = L1Loss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               3.35999990)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               3.), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.35999998)}
 
         >>> loss = L1Loss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               6.71999979)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               6.), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.71999997)}
     """
 
     def __init__(
@@ -156,14 +158,16 @@ class PeriodicL1Loss(base.Loss):
         >>> loss = PeriodicL1Loss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               4.19999981)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               3.35999990), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.83999997)}
 
         >>> loss = PeriodicL1Loss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               4.19999981)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               3.35999990), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.83999997)}
     """
 
     def __init__(

--- a/ppsci/loss/l2.py
+++ b/ppsci/loss/l2.py
@@ -83,8 +83,11 @@ class L2Loss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             loss = F.mse_loss(output_dict[key], label_dict[key], "none")
             if weight_dict and key in weight_dict:
@@ -105,7 +108,8 @@ class L2Loss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses
 
 
@@ -168,8 +172,11 @@ class PeriodicL2Loss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             n_output = len(output_dict[key])
             if n_output % 2 > 0:
@@ -199,7 +206,8 @@ class PeriodicL2Loss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses
 
 
@@ -271,8 +279,11 @@ class L2RelLoss(base.Loss):
         y_norms = paddle.norm(y_, p=2, axis=1)
         return diff_norms / y_norms
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             loss = self.rel_loss(output_dict[key], label_dict[key])
             if weight_dict:
@@ -288,6 +299,6 @@ class L2RelLoss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
 
         return losses

--- a/ppsci/loss/l2.py
+++ b/ppsci/loss/l2.py
@@ -63,13 +63,15 @@ class L2Loss(base.Loss):
         >>> loss = L2Loss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               2.78884506)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               2.52735591), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.26148924)}
         >>> loss = L2Loss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               5.57769012)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               5.05471182), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.52297848)}
     """
 
     def __init__(
@@ -151,14 +153,16 @@ class PeriodicL2Loss(base.Loss):
         >>> loss = PeriodicL2Loss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               2.67581749)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               2.14065409), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.53516352)}
 
         >>> loss = PeriodicL2Loss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               2.67581749)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               2.14065409), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.53516352)}
     """
 
     def __init__(
@@ -250,14 +254,16 @@ class L2RelLoss(base.Loss):
         >>> loss = L2RelLoss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               2.93676996)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               1.08776188), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               1.84900820)}
 
         >>> loss = L2RelLoss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               5.87353992)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               2.17552376), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               3.69801641)}
     """
 
     def __init__(

--- a/ppsci/loss/mae.py
+++ b/ppsci/loss/mae.py
@@ -59,14 +59,16 @@ class MAELoss(base.Loss):
         >>> loss = MAELoss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               1.67999995)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               1.50000000), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.17999999)}
 
         >>> loss = MAELoss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               6.71999979)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               6.), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.71999997)}
     """
 
     def __init__(

--- a/ppsci/loss/mae.py
+++ b/ppsci/loss/mae.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import Optional
 from typing import Union
@@ -22,6 +23,9 @@ import paddle.nn.functional as F
 from typing_extensions import Literal
 
 from ppsci.loss import base
+
+if TYPE_CHECKING:
+    import paddle
 
 
 class MAELoss(base.Loss):
@@ -76,8 +80,11 @@ class MAELoss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             loss = F.l1_loss(output_dict[key], label_dict[key], "none")
             if weight_dict and key in weight_dict:
@@ -95,5 +102,6 @@ class MAELoss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses

--- a/ppsci/loss/mse.py
+++ b/ppsci/loss/mse.py
@@ -77,8 +77,11 @@ class MSELoss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             loss = F.mse_loss(output_dict[key], label_dict[key], "none")
             if weight_dict and key in weight_dict:
@@ -96,7 +99,8 @@ class MSELoss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses
 
 
@@ -148,8 +152,11 @@ class CausalMSELoss(base.Loss):
             "acc_mat", paddle.tril(paddle.ones([n_chunks, n_chunks]), -1)
         )
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             loss = F.mse_loss(output_dict[key], label_dict[key], "none")
             if weight_dict and key in weight_dict:
@@ -175,7 +182,8 @@ class CausalMSELoss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses
 
 
@@ -241,13 +249,16 @@ class MSELossWithL2Decay(MSELoss):
         super().__init__(reduction, weight)
         self.regularization_dict = regularization_dict
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
         losses = super().forward(output_dict, label_dict, weight_dict)
 
         if self.regularization_dict is not None:
             for reg_key, reg_weight in self.regularization_dict.items():
                 loss = output_dict[reg_key].pow(2).sum()
-                losses += loss * reg_weight
+                losses[reg_key] += loss * reg_weight
+
         return losses
 
 
@@ -302,8 +313,11 @@ class PeriodicMSELoss(base.Loss):
             )
         super().__init__(reduction, weight)
 
-    def forward(self, output_dict, label_dict, weight_dict=None):
-        losses = 0.0
+    def forward(
+        self, output_dict, label_dict, weight_dict=None
+    ) -> Dict[str, "paddle.Tensor"]:
+        losses = {}
+
         for key in label_dict:
             n_output = len(output_dict[key])
             if n_output % 2 > 0:
@@ -330,5 +344,6 @@ class PeriodicMSELoss(base.Loss):
             elif isinstance(self.weight, dict) and key in self.weight:
                 loss *= self.weight[key]
 
-            losses += loss
+            losses[key] = loss
+
         return losses

--- a/ppsci/loss/mse.py
+++ b/ppsci/loss/mse.py
@@ -228,7 +228,7 @@ class MSELossWithL2Decay(MSELoss):
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
         {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               12.20599937), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               7.91999960), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
                0.18800001)}
 
         >>> regularization_dict = {'v': 1.0}
@@ -237,7 +237,7 @@ class MSELossWithL2Decay(MSELoss):
         >>> print(result)
         {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
                17.14400101), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               4.71199989)}
+               3.95999980)}
     """
 
     def __init__(

--- a/ppsci/loss/mse.py
+++ b/ppsci/loss/mse.py
@@ -261,7 +261,7 @@ class MSELossWithL2Decay(MSELoss):
         if self.regularization_dict is not None:
             for reg_key, reg_weight in self.regularization_dict.items():
                 loss = output_dict[reg_key].pow(2).sum()
-                losses[reg_key] += loss * reg_weight
+                losses[reg_key] = loss * reg_weight
 
         return losses
 

--- a/ppsci/loss/mse.py
+++ b/ppsci/loss/mse.py
@@ -56,14 +56,16 @@ class MSELoss(base.Loss):
         >>> loss = MSELoss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               4.47400045)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               4.28600025), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.18800001)}
 
         >>> loss = MSELoss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               17.89600182)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               17.14400101), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.75200003)}
     """
 
     def __init__(
@@ -128,8 +130,8 @@ class CausalMSELoss(base.Loss):
         >>> loss = CausalMSELoss(n_chunks=3)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               0.96841478)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.96841478)}
     """
 
     def __init__(
@@ -225,15 +227,17 @@ class MSELossWithL2Decay(MSELoss):
         >>> loss = MSELossWithL2Decay(regularization_dict=regularization_dict, weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               12.39400005)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               12.20599937), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.18800001)}
 
         >>> regularization_dict = {'v': 1.0}
         >>> loss = MSELossWithL2Decay(reduction="sum", regularization_dict=regularization_dict, weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               21.85600090)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               17.14400101), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               4.71199989)}
     """
 
     def __init__(
@@ -292,14 +296,16 @@ class PeriodicMSELoss(base.Loss):
         >>> loss = PeriodicMSELoss(weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               2.59999967)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               2.07999969), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               0.51999992)}
 
         >>> loss = PeriodicMSELoss(reduction="sum", weight=weight)
         >>> result = loss(output_dict, label_dict)
         >>> print(result)
-        Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-               5.19999933)
+        {'u': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               4.15999937), 'v': Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+               1.03999984)}
     """
 
     def __init__(

--- a/ppsci/loss/mtl/agda.py
+++ b/ppsci/loss/mtl/agda.py
@@ -73,9 +73,9 @@ class AGDA(base.LossAggregator):
     def _compute_grads(self) -> List[paddle.Tensor]:
         # compute all gradients derived by each loss
         grads_list = []  # num_params x num_losses
-        for loss in self.losses:
+        for key in self.losses:
             # backward with current loss
-            loss.backward()
+            self.losses[key].backward()
             grads_list.append(
                 paddle.concat(
                     [

--- a/ppsci/loss/mtl/agda.py
+++ b/ppsci/loss/mtl/agda.py
@@ -28,6 +28,8 @@ class AGDA(base.LossAggregator):
 
     [Physics-informed neural network based on a new adaptive gradient descent algorithm for solving partial differential equations of flow problems](https://pubs.aip.org/aip/pof/article-abstract/35/6/063608/2899773/Physics-informed-neural-network-based-on-a-new)
 
+    NOTE: This loss aggregator is only suitable for two-task learning and the first task loss must be PDE loss.
+
     Args:
         model (nn.Layer): Training model.
         M (int, optional): Smoothing period. Defaults to 100.
@@ -43,9 +45,9 @@ class AGDA(base.LossAggregator):
         ...     x2 = paddle.randn([8, 3])
         ...     y1 = model(x1)
         ...     y2 = model(x2)
-        ...     loss1 = paddle.sum(y1)
-        ...     loss2 = paddle.sum((y2 - 2) ** 2)
-        ...     loss_aggregator([loss1, loss2]).backward()
+        ...     pde_loss = paddle.sum(y1)
+        ...     bc_loss = paddle.sum((y2 - 2) ** 2)
+        ...     loss_aggregator({'pde_loss': pde_loss, 'bc_loss': bc_loss}).backward()
     """
 
     def __init__(self, model: nn.Layer, M: int = 100, gamma: float = 0.999) -> None:
@@ -93,11 +95,12 @@ class AGDA(base.LossAggregator):
 
     def _refine_grads(self, grads_list: List[paddle.Tensor]) -> List[paddle.Tensor]:
         # compute moving average of L^smooth_i(n) - eq.(16)
+        losses_seq = list(self.losses.values())
         self.Lf_smooth = (
-            self.gamma * self.Lf_smooth + (1 - self.gamma) * self.losses[0].item()
+            self.gamma * self.Lf_smooth + (1 - self.gamma) * losses_seq[0].item()
         )
         self.Lu_smooth = (
-            self.gamma * self.Lu_smooth + (1 - self.gamma) * self.losses[1].item()
+            self.gamma * self.Lu_smooth + (1 - self.gamma) * losses_seq[1].item()
         )
 
         # compute L^smooth_i(kM) - eq.(17)

--- a/ppsci/loss/mtl/base.py
+++ b/ppsci/loss/mtl/base.py
@@ -14,7 +14,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from typing import Dict
+from typing import Union
+
 from paddle import nn
+
+if TYPE_CHECKING:
+    import paddle
 
 
 class LossAggregator(nn.Layer):
@@ -33,7 +40,9 @@ class LossAggregator(nn.Layer):
             if not param.stop_gradient:
                 self.param_num += 1
 
-    def forward(self, losses, step: int = 0) -> "LossAggregator":
+    def forward(
+        self, losses: Dict[str, "paddle.Tensor"], step: int = 0
+    ) -> Union["paddle.Tensor", "LossAggregator"]:
         self.losses = losses
         self.loss_num = len(losses)
         self.step = step

--- a/ppsci/loss/mtl/grad_norm.py
+++ b/ppsci/loss/mtl/grad_norm.py
@@ -50,7 +50,7 @@ class GradNorm(base.LossAggregator):
         >>> import paddle
         >>> from ppsci.loss import mtl
         >>> model = paddle.nn.Linear(3, 4)
-        >>> loss_aggregator = mtl.GradNorm(num_losses=2)
+        >>> loss_aggregator = mtl.GradNorm(model, num_losses=2)
         >>> for i in range(5):
         ...     x1 = paddle.randn([8, 3])
         ...     x2 = paddle.randn([8, 3])
@@ -114,7 +114,7 @@ class GradNorm(base.LossAggregator):
 
         # update moving weights every 'update_freq' steps
         if self.step % self.update_freq == 0:
-            weight = self._compute_weight(losses)
+            weight = self._compute_weight(list(losses.values()))
             for i in range(self.num_losses):
                 self.weight[i].set_value(
                     self.momentum * self.weight[i] + (1 - self.momentum) * weight[i]

--- a/ppsci/loss/mtl/grad_norm.py
+++ b/ppsci/loss/mtl/grad_norm.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from typing import Dict
 from typing import List
 
 import paddle
@@ -44,6 +45,20 @@ class GradNorm(base.LossAggregator):
         num_losses (int, optional): Number of losses. Defaults to 1.
         update_freq (int, optional): Weight updating frequency. Defaults to 1000.
         momentum (float, optional): Momentum $m$ for moving weight. Defaults to 0.9.
+
+    Examples:
+        >>> import paddle
+        >>> from ppsci.loss import mtl
+        >>> model = paddle.nn.Linear(3, 4)
+        >>> loss_aggregator = mtl.GradNorm(num_losses=2)
+        >>> for i in range(5):
+        ...     x1 = paddle.randn([8, 3])
+        ...     x2 = paddle.randn([8, 3])
+        ...     y1 = model(x1)
+        ...     y2 = model(x2)
+        ...     loss1 = paddle.sum(y1)
+        ...     loss2 = paddle.sum((y2 - 2) ** 2)
+        ...     loss_aggregator({'loss1': loss1, 'loss2': loss2}).backward()
     """
 
     def __init__(
@@ -80,7 +95,9 @@ class GradNorm(base.LossAggregator):
 
         return weight
 
-    def __call__(self, losses: List["paddle.Tensor"], step: int = 0) -> "paddle.Tensor":
+    def __call__(
+        self, losses: Dict[str, "paddle.Tensor"], step: int = 0
+    ) -> "paddle.Tensor":
         assert len(losses) == self.num_losses, (
             f"Length of given losses({len(losses)}) should be equal to "
             f"num_losses({self.num_losses})."
@@ -88,9 +105,12 @@ class GradNorm(base.LossAggregator):
         self.step = step
 
         # compute current loss with moving weights
-        loss = self.weight[0] * losses[0]
-        for i in range(1, len(losses)):
-            loss += self.weight[i] * losses[i]
+        loss = 0.0
+        for i, key in enumerate(losses):
+            if i == 0:
+                loss = self.weight[i] * losses[key]
+            else:
+                loss += self.weight[i] * losses[key]
 
         # update moving weights every 'update_freq' steps
         if self.step % self.update_freq == 0:

--- a/ppsci/loss/mtl/pcgrad.py
+++ b/ppsci/loss/mtl/pcgrad.py
@@ -54,7 +54,11 @@ class PCGrad(base.LossAggregator):
         self._zero = paddle.zeros([])
 
     def backward(self) -> None:
-        np.random.shuffle(self.losses)
+        # shuffle order of losses
+        keys = list(self.losses.keys())
+        np.random.shuffle(keys)
+        self.losses = {key: self.losses[key] for key in keys}
+
         grads_list = self._compute_grads()
         with paddle.no_grad():
             refined_grads = self._refine_grads(grads_list)
@@ -63,9 +67,9 @@ class PCGrad(base.LossAggregator):
     def _compute_grads(self) -> List[paddle.Tensor]:
         # compute all gradients derived by each loss
         grads_list = []  # num_params x num_losses
-        for loss in self.losses:
+        for key in self.losses:
             # backward with current loss
-            loss.backward()
+            self.losses[key].backward()
             grads_list.append(
                 paddle.concat(
                     [

--- a/ppsci/loss/mtl/pcgrad.py
+++ b/ppsci/loss/mtl/pcgrad.py
@@ -46,7 +46,7 @@ class PCGrad(base.LossAggregator):
         ...     y2 = model(x2)
         ...     loss1 = paddle.sum(y1)
         ...     loss2 = paddle.sum((y2 - 2) ** 2)
-        ...     loss_aggregator([loss1, loss2]).backward()
+        ...     loss_aggregator({'loss1': loss1, 'loss2': loss2}).backward()
     """
 
     def __init__(self, model: nn.Layer) -> None:

--- a/ppsci/loss/mtl/relobralo.py
+++ b/ppsci/loss/mtl/relobralo.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict
 
 import paddle
 from paddle import nn
@@ -81,13 +81,15 @@ class Relobralo(nn.Layer):
             self._softmax(losses_vec1 / (self.tau * losses_vec2 + self.eps))
         )
 
-    def __call__(self, losses: List["paddle.Tensor"], step: int = 0) -> "paddle.Tensor":
+    def __call__(
+        self, losses: Dict[str, "paddle.Tensor"], step: int = 0
+    ) -> "paddle.Tensor":
         assert len(losses) == self.num_losses, (
             f"Length of given losses({len(losses)}) should be equal to "
             f"num_losses({self.num_losses})."
         )
         self.step = step
-        losses_stacked = paddle.stack(losses)  # [num_losses, ]
+        losses_stacked = paddle.stack(list(losses.values()))  # [num_losses, ]
 
         if self.step == 0:
             loss = losses_stacked.sum()

--- a/ppsci/loss/mtl/relobralo.py
+++ b/ppsci/loss/mtl/relobralo.py
@@ -47,7 +47,7 @@ class Relobralo(nn.Layer):
         ...     y2 = model(x2)
         ...     loss1 = paddle.sum(y1)
         ...     loss2 = paddle.sum((y2 - 2) ** 2)
-        ...     loss_aggregator([loss1, loss2]).backward()
+        ...     loss_aggregator({'loss1': loss1, 'loss2': loss2}).backward()
     """
 
     def __init__(

--- a/ppsci/loss/mtl/sum.py
+++ b/ppsci/loss/mtl/sum.py
@@ -48,6 +48,6 @@ class Sum(LossAggregator):
             if i == 0:
                 total_loss = losses[key]
             else:
-                total_loss += losses[i]
+                total_loss += losses[key]
 
         return total_loss

--- a/ppsci/loss/mtl/sum.py
+++ b/ppsci/loss/mtl/sum.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Sequence
+from typing import Dict
 
 if TYPE_CHECKING:
     import paddle
@@ -36,15 +36,18 @@ class Sum(LossAggregator):
         self.step = 0
 
     def __call__(
-        self, losses: Sequence["paddle.Tensor"], step: int = 0
-    ) -> paddle.Tensor:
+        self, losses: Dict[str, "paddle.Tensor"], step: int = 0
+    ) -> "paddle.Tensor":
         assert (
             len(losses) > 0
         ), f"Number of given losses({len(losses)}) can not be empty."
         self.step = step
 
-        loss = losses[0]
-        for i in range(1, len(losses)):
-            loss += losses[i]
+        total_loss = 0.0
+        for i, key in enumerate(losses):
+            if i == 0:
+                total_loss = losses[key]
+            else:
+                total_loss += losses[i]
 
-        return loss
+        return total_loss

--- a/ppsci/metric/anomaly_coef.py
+++ b/ppsci/metric/anomaly_coef.py
@@ -87,8 +87,9 @@ class LatitudeWeightedACC(base.Metric):
         return self.scale * paddle.expm1(x)
 
     @paddle.no_grad()
-    def forward(self, output_dict, label_dict):
+    def forward(self, output_dict, label_dict) -> Dict[str, "paddle.Tensor"]:
         metric_dict = {}
+
         for key in label_dict:
             output = (
                 self.scale_expm1(output_dict[key]) if self.unlog else output_dict[key]
@@ -117,4 +118,5 @@ class LatitudeWeightedACC(base.Metric):
                     metric_dict[key] = rmse.mean(axis=1)
                 else:
                     metric_dict[key] = rmse.mean()
+
         return metric_dict

--- a/ppsci/metric/func.py
+++ b/ppsci/metric/func.py
@@ -14,9 +14,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Callable
+from typing import Dict
 
 from ppsci.metric import base
+
+if TYPE_CHECKING:
+    import paddle
 
 
 class FunctionalMetric(base.Metric):
@@ -54,5 +59,5 @@ class FunctionalMetric(base.Metric):
         super().__init__(keep_batch)
         self.metric_expr = metric_expr
 
-    def forward(self, output_dict, label_dict=None):
+    def forward(self, output_dict, label_dict=None) -> Dict[str, "paddle.Tensor"]:
         return self.metric_expr(output_dict, label_dict)

--- a/ppsci/metric/l2_rel.py
+++ b/ppsci/metric/l2_rel.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import Dict
+
 import numpy as np
 import paddle
 
@@ -64,7 +66,7 @@ class L2Rel(base.Metric):
         super().__init__(keep_batch)
 
     @paddle.no_grad()
-    def forward(self, output_dict, label_dict):
+    def forward(self, output_dict, label_dict) -> Dict[str, "paddle.Tensor"]:
         metric_dict = {}
         for key in label_dict:
             rel_l2 = paddle.norm(label_dict[key] - output_dict[key], p=2) / paddle.norm(
@@ -123,7 +125,7 @@ class MeanL2Rel(base.Metric):
         super().__init__(keep_batch)
 
     @paddle.no_grad()
-    def forward(self, output_dict, label_dict):
+    def forward(self, output_dict, label_dict) -> Dict[str, "paddle.Tensor"]:
         metric_dict = {}
         for key in label_dict:
             rel_l2 = paddle.norm(

--- a/ppsci/metric/mae.py
+++ b/ppsci/metric/mae.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import Dict
+
 import paddle
 import paddle.nn.functional as F
 
@@ -59,7 +61,7 @@ class MAE(base.Metric):
         super().__init__(keep_batch)
 
     @paddle.no_grad()
-    def forward(self, output_dict, label_dict):
+    def forward(self, output_dict, label_dict) -> Dict[str, "paddle.Tensor"]:
         metric_dict = {}
         for key in label_dict:
             mae = F.l1_loss(output_dict[key], label_dict[key], "none")

--- a/ppsci/metric/mse.py
+++ b/ppsci/metric/mse.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import Dict
+
 import paddle
 import paddle.nn.functional as F
 
@@ -59,7 +61,7 @@ class MSE(base.Metric):
         super().__init__(keep_batch)
 
     @paddle.no_grad()
-    def forward(self, output_dict, label_dict):
+    def forward(self, output_dict, label_dict) -> Dict[str, "paddle.Tensor"]:
         metric_dict = {}
         for key in label_dict:
             mse = F.mse_loss(output_dict[key], label_dict[key], "none")

--- a/ppsci/metric/rmse.py
+++ b/ppsci/metric/rmse.py
@@ -61,7 +61,7 @@ class RMSE(base.Metric):
         super().__init__(keep_batch)
 
     @paddle.no_grad()
-    def forward(self, output_dict, label_dict):
+    def forward(self, output_dict, label_dict) -> Dict[str, "paddle.Tensor"]:
         metric_dict = {}
         for key in label_dict:
             rmse = F.mse_loss(output_dict[key], label_dict[key], "mean") ** 0.5
@@ -132,7 +132,7 @@ class LatitudeWeightedRMSE(base.Metric):
         return self.scale * paddle.expm1(x)
 
     @paddle.no_grad()
-    def forward(self, output_dict, label_dict):
+    def forward(self, output_dict, label_dict) -> Dict[str, "paddle.Tensor"]:
         metric_dict = {}
         for key in label_dict:
             output = (

--- a/ppsci/solver/eval.py
+++ b/ppsci/solver/eval.py
@@ -112,7 +112,9 @@ def _eval_by_dataset(
                     weight_dict,
                 )
 
-            loss_dict[f"{_validator.name}/loss"] = float(validator_loss)
+            loss_dict[f"{_validator.name}/loss"] = float(
+                sum(list(validator_loss.values()))
+            )
 
             for key, output in output_dict.items():
                 all_output[key].append(
@@ -213,6 +215,7 @@ def _eval_by_batch(
         num_samples = _get_dataset_length(_validator.data_loader)
 
         loss_dict = misc.Prettydefaultdict(float)
+        metric_dict_group: Dict[str, Dict[str, float]] = misc.PrettyOrderedDict()
         reader_tic = time.perf_counter()
         batch_tic = time.perf_counter()
         for iter_id, batch in enumerate(_validator.data_loader, start=1):
@@ -242,7 +245,9 @@ def _eval_by_batch(
                     weight_dict,
                 )
 
-            loss_dict[f"{_validator.name}/loss"] = float(validator_loss)
+            loss_dict[f"{_validator.name}/loss"] = float(
+                sum(list(validator_loss.values()))
+            )
 
             # collect batch metric
             for metric_name, metric_func in _validator.metric.items():

--- a/ppsci/solver/eval.py
+++ b/ppsci/solver/eval.py
@@ -77,6 +77,7 @@ def _eval_by_dataset(
             computed during evaluation.
     """
     target_metric: float = float("inf")
+    metric_dict_group: Dict[str, Dict[str, float]] = misc.PrettyOrderedDict()
     for _, _validator in solver.validator.items():
         all_output = misc.Prettydefaultdict(list)
         all_label = misc.Prettydefaultdict(list)
@@ -161,7 +162,6 @@ def _eval_by_dataset(
             if len(all_label[key]) > num_samples:
                 all_label[key] = all_label[key][:num_samples]
 
-        metric_dict_group: Dict[str, Dict[str, float]] = misc.PrettyOrderedDict()
         for metric_name, metric_func in _validator.metric.items():
             # NOTE: compute metric with entire output and label
             metric_dict = metric_func(all_output, all_label)
@@ -208,11 +208,11 @@ def _eval_by_batch(
             computed during evaluation.
     """
     target_metric: float = float("inf")
+    metric_dict_group: Dict[str, Dict[str, float]] = misc.PrettyOrderedDict()
     for _, _validator in solver.validator.items():
         num_samples = _get_dataset_length(_validator.data_loader)
 
         loss_dict = misc.Prettydefaultdict(float)
-        metric_dict_group: Dict[str, Dict[str, float]] = misc.PrettyOrderedDict()
         reader_tic = time.perf_counter()
         batch_tic = time.perf_counter()
         for iter_id, batch in enumerate(_validator.data_loader, start=1):

--- a/ppsci/solver/train.py
+++ b/ppsci/solver/train.py
@@ -97,6 +97,10 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
                     label_dicts,
                     weight_dicts,
                 )
+                assert "loss" not in constraint_losses, (
+                    "Key 'loss' is not allowed in loss_dict for it is an preserved key"
+                    " representing total loss, please use other name instead."
+                )
 
                 if solver.nvtx_flag:  # only for nsight analysis
                     core.nvprof_nvtx_pop()  # Loss computation

--- a/ppsci/solver/train.py
+++ b/ppsci/solver/train.py
@@ -115,9 +115,11 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
                 if solver.update_freq > 1:
                     total_loss = total_loss / solver.update_freq
 
-                loss_dict = {
-                    key: float(loss) for key, loss in constraint_losses.items()
-                }
+                for i, _constraint in enumerate(solver.constraint.values()):
+                    loss_dict[_constraint.name] = 0.0
+                    for key in _constraint.output_keys:
+                        loss_dict[_constraint.name] += float(constraint_losses[key])
+
                 loss_dict["loss"] = float(total_loss)
 
                 if solver.nvtx_flag:  # only for nsight analysis

--- a/ppsci/solver/train.py
+++ b/ppsci/solver/train.py
@@ -78,6 +78,8 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
             total_batch_size += next(iter(input_dict.values())).shape[0]
             reader_tic = time.perf_counter()
 
+        loss_dict = misc.Prettydefaultdict(float)
+        loss_dict["loss"] = 0.0
         # forward for every constraint, including model and equation expression
         with solver.no_sync_context_manager(solver.world_size > 1, solver.model):
             with solver.autocast_context_manager(solver.use_amp, solver.amp_level):
@@ -111,7 +113,7 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
                 if solver.update_freq > 1:
                     total_loss = total_loss / solver.update_freq
 
-                loss_dict = losses_constraint
+                loss_dict.update(losses_constraint)
                 loss_dict["loss"] = float(total_loss)
 
                 if solver.nvtx_flag:  # only for nsight analysis

--- a/ppsci/solver/train.py
+++ b/ppsci/solver/train.py
@@ -115,10 +115,9 @@ def train_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int):
                 if solver.update_freq > 1:
                     total_loss = total_loss / solver.update_freq
 
-                for i, _constraint in enumerate(solver.constraint.values()):
-                    loss_dict[_constraint.name] = (
-                        float(constraint_losses[i]) / solver.update_freq
-                    )
+                loss_dict = {
+                    key: float(loss) for key, loss in constraint_losses.items()
+                }
                 loss_dict["loss"] = float(total_loss)
 
                 if solver.nvtx_flag:  # only for nsight analysis
@@ -250,12 +249,13 @@ def train_LBFGS_epoch_func(solver: "solver.Solver", epoch_id: int, log_freq: int
                         weight_dicts,
                     )
 
+                    # accumulate all losses
                     total_loss = solver.loss_aggregator(
                         constraint_losses, solver.global_step
                     )
-                    # accumulate all losses
-                    for i, _constraint in enumerate(solver.constraint.values()):
-                        loss_dict[_constraint.name] = float(constraint_losses[i])
+                    loss_dict = {
+                        key: float(loss) for key, loss in constraint_losses.items()
+                    }
                     loss_dict["loss"] = float(total_loss)
 
                 # backward

--- a/ppsci/utils/expression.py
+++ b/ppsci/utils/expression.py
@@ -144,7 +144,7 @@ class ExpressionSolver(nn.Layer):
             weight_dict (Dict[str, paddle.Tensor]): Weight dict.
 
         Returns:
-            Tuple[Dict[str, paddle.Tensor], paddle.Tensor]: Result dict and loss for
+            Tuple[Dict[str, paddle.Tensor], Dict[str, paddle.Tensor]]: Result dict and loss for
                 given validator.
         """
         # model forward

--- a/ppsci/utils/expression.py
+++ b/ppsci/utils/expression.py
@@ -114,6 +114,9 @@ class ExpressionSolver(nn.Layer):
                 label_dicts[i],
                 weight_dicts[i],
             )
+            # update losses into 'losses_all' and 'losses_constraint'
+            # 'losses_all': Will be send to loss aggregator for further computing final loss(scalar)
+            # 'losses_constraint': Will be used in logging
             losses_constraint[cst_name] = 0.0
             for key in losses:
                 losses_constraint[cst_name] += losses[key].item()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
1. 修改 loss 模块的返回值，从标量`Tensor`修改为未经过求和的`Dict[str, Tensor]`，使得`aggregator`模块接收到的losses是output_keys粒度而不是constraint_name粒度的字典，以应对同一个constraint不同output_key具有不同的权重的情况。
2. 修改所有使用了loss模块的代码和Examples样例
3. 删除`Constraint`中将`area`添加到`output_keys`的逻辑