### PR TITLE
[Fix] Remove redundant ignore_module in to_static and fix cvit_ns export

### DIFF
--- a/ppsci/arch/cvit.py
+++ b/ppsci/arch/cvit.py
@@ -517,10 +517,11 @@ def dot_product_attention_weights(
     """
     dtype = query.dtype
 
-    assert query.ndim == key.ndim, "q, k must have same rank."
-    assert query.shape[:-3] == key.shape[:-3], "q, k batch dims must match."
-    assert query.shape[-2] == key.shape[-2], "q, k num_heads must match."
-    assert query.shape[-1] == key.shape[-1], "q, k depths must match."
+    if paddle.in_dynamic_mode():
+        assert query.ndim == key.ndim, "q, k must have same rank."
+        assert query.shape[:-3] == key.shape[:-3], "q, k batch dims must match."
+        assert query.shape[-2] == key.shape[-2], "q, k num_heads must match."
+        assert query.shape[-1] == key.shape[-1], "q, k depths must match."
 
     # calculate attention matrix
     depth = query.shape[-1]
@@ -567,14 +568,15 @@ def dot_product_attention(
     Returns:
         paddle.Tensor: Output of shape [batch..., q_length, num_heads, v_depth_per_head].
     """
-    assert key.ndim == query.ndim == value.ndim, "q, k, v must have same rank."
-    assert (
-        query.shape[:-3] == key.shape[:-3] == value.shape[:-3]
-    ), "q, k, v batch dims must match."
-    assert (
-        query.shape[-2] == key.shape[-2] == value.shape[-2]
-    ), "q, k, v num_heads must match."
-    assert key.shape[-3] == value.shape[-3], "k, v lengths must match."
+    if paddle.in_dynamic_mode():
+        assert key.ndim == query.ndim == value.ndim, "q, k, v must have same rank."
+        assert (
+            query.shape[:-3] == key.shape[:-3] == value.shape[:-3]
+        ), "q, k, v batch dims must match."
+        assert (
+            query.shape[-2] == key.shape[-2] == value.shape[-2]
+        ), "q, k, v num_heads must match."
+        assert key.shape[-3] == value.shape[-3], "k, v lengths must match."
 
     # compute attention weights
     attn_weights = dot_product_attention_weights(

--- a/ppsci/solver/solver.py
+++ b/ppsci/solver/solver.py
@@ -917,7 +917,6 @@ class Solver:
             self.model,
             input_spec=input_spec,
             full_graph=full_graph,
-            ignore_module=ignore_modules,
         )
 
         # save static graph model to disk


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
1. 删除导出模型时多余的参数：ignore_module
2. 将cvit_ns的assert移动到in_dynamic_mode下