### PR TITLE
[Example]modify log msg to string of Catheter example

### DIFF
--- a/examples/catheter/catheter.py
+++ b/examples/catheter/catheter.py
@@ -203,11 +203,10 @@ def evaluate(cfg: DictConfig):
             .numpy()
             .flatten()
         )
-        logger.info(
-            "rel. error is ",
-            np.linalg.norm(y_test_pred - y_test[sample_id, :].flatten())
-            / np.linalg.norm(y_test[sample_id, :].flatten()),
-        )
+        error = np.linalg.norm(
+            y_test_pred - y_test[sample_id, :].flatten()
+        ) / np.linalg.norm(y_test[sample_id, :].flatten())
+        logger.info(f"rel. error is {error}")
         xx = np.linspace(-500, 0, 2001)
         plt.figure(figsize=(5, 4))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix the bug in this example that the error message is not a string