### PR TITLE
Update requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ mkdocs-include-markdown-plugin
 mkdocs-material
 mkdocs-material-extensions
 mkdocs-video
-mkdocstrings
+mkdocstrings==0.27.0
 mkdocstrings-python
 numpy>=1.20.0,<2.0.0
 pyyaml


### PR DESCRIPTION
Fix mkdocstings to 0.27.0 to avoid build failure

<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs 
### Describe
<!-- Describe what this PR does -->
固定mkdocstrings的版本为0.27.0，否则0.28.0构建文档时会报错