### PR TITLE
[sdaa]:adapt hpinn and cgcnn on custom device sdaa

### DIFF
--- a/deploy/python_infer/base.py
+++ b/deploy/python_infer/base.py
@@ -214,9 +214,9 @@ class Predictor:
         return predictor, config
 
     def _check_device(self, device: str):
-        if device not in ["cpu", "gpu", "npu", "xpu"]:
+        if device not in ["cpu", "gpu", "npu", "xpu", "sdaa"]:
             raise ValueError(
-                "Inference only supports 'gpu', 'cpu', 'npu' and 'xpu' devices, "
+                "Inference only supports 'gpu', 'cpu', 'npu', 'xpu' and 'sdaa' devices, "
                 f"but got {device}."
             )
 

--- a/docs/zh/multi_device.md
+++ b/docs/zh/multi_device.md
@@ -66,8 +66,8 @@
 
     | 问题类型 | 案例名称 | NVIDIA | 海光 | 太初 | 沐曦 |
     |-----|-----|-----|-----|-----|-----|
-    | 材料设计 | [散射板设计(反问题)](./examples/hpinns.md) | ✅ | | | ✅ |
-    | 材料设计 | [CGCNN](./examples/cgcnn.md) | ✅ | | | |
+    | 材料设计 | [散射板设计(反问题)](./examples/hpinns.md) | ✅ | | ✅ | ✅ |
+    | 材料设计 | [CGCNN](./examples/cgcnn.md) | ✅ | | ✅ | |
 
 === "地球科学(AI for Earth Science)"
 


### PR DESCRIPTION
### PR types
New features

### PR changes
Docs&Codes

### Describe
为材料科学领域的hpinn和cgcnn模型添加太初硬件支持信息
为模型的推理脚本添加sdaa设备信息

### Environments
![image](https://github.com/user-attachments/assets/3c09f2ba-d896-44e9-b435-3ccb8f38b63a)
芯片型号：T100
各组件版本信息如上图所示，包括驱动、算子库等全部依赖组件

### Logs
[hpinn_train.log](https://github.com/user-attachments/files/19386261/hpinn_train.log)
[hpinn_eval.log](https://github.com/user-attachments/files/19386262/hpinn_eval.log)
[cgcnn_train.log](https://github.com/user-attachments/files/19386263/cgcnn_train.log)
[cgcnn_eval.log](https://github.com/user-attachments/files/19386264/cgcnn_eval.log)
pdparams文件较大，无法上传，如有所需，请联系开发者单独提供

### Results
hpinn sdaa精度值：
    loss(opt_sup): 0.05244
    MSE.eval_metric(opt_sup): 0.00002
    loss(val_sup): 0.02057
    MSE.eval_metric(val_sup): 0.00001
hpinn cuda精度值：
    loss(opt_sup): 0.05352
    MSE.eval_metric(opt_sup): 0.00002
    loss(val_sup): 0.02205
    MSE.eval_metric(val_sup): 0.00001

cgcnn sdaa精度值：0.08852（MAE）
cgcnn cuda精度值：0.4195（MAE）
均符合精度对齐要求