### PR TITLE
[sdaa]:adapt deeponet,laplace,lorenz,euler_beam models on device sdaa

### DIFF
--- a/docs/zh/multi_device.md
+++ b/docs/zh/multi_device.md
@@ -12,12 +12,12 @@
     |-----|-----|-----|-----|-----|-----|
     | 亥姆霍兹方程 | [SPINN(Helmholtz3D)](./examples/spinn.md) | ✅ | | | ✅ |
     | 相场方程 | [Allen-Cahn](./examples/allen_cahn.md) | ✅ | | | ✅ |
-    | 微分方程 | [拉普拉斯方程](./examples/laplace2d.md) | ✅ | | | ✅ |
+    | 微分方程 | [拉普拉斯方程](./examples/laplace2d.md) | ✅ | | ✅ | ✅ |
     | 微分方程 | [伯格斯方程](./examples/deephpms.md) | ✅ | | | ✅ |
     | 微分方程 | [非线性偏微分方程](./examples/pirbn.md) | ✅ | | | ✅ |
-    | 微分方程 | [洛伦兹方程](./examples/lorenz.md) | ✅ | | | ✅ |
+    | 微分方程 | [洛伦兹方程](./examples/lorenz.md) | ✅ | | ✅ | ✅ |
     | 微分方程 | [若斯叻方程](./examples/rossler.md) | ✅ | | | ✅ |
-    | 算子学习 | [DeepONet](./examples/deeponet.md) | ✅ | | | ✅ |
+    | 算子学习 | [DeepONet](./examples/deeponet.md) | ✅ | | ✅ | ✅ |
     | 积分方程 | [沃尔泰拉积分方程](./examples/volterra_ide.md) | ✅ | | | ✅ |
     | 光纤怪波 | [Optical rogue wave](./examples/nlsmb.md) | ✅ | | | ✅ |
     | 域分解 | [XPINN](./examples/xpinns.md) | ✅ | | ✅ | ✅ |
@@ -45,7 +45,7 @@
     | 多相流 | [气液两相流](./examples/bubble.md) | ✅ | | | ✅ |
     | 流场高分辨率重构 | [2D 湍流流场重构](./examples/tempoGAN.md) | ✅ | | | ✅ |
     | 求解器耦合 | [CFD-GCN](./examples/cfdgcn.md) | ✅ | | | |
-    | 受力分析 | [1D 欧拉梁变形](./examples/euler_beam.md) | ✅ | | | ✅ |
+    | 受力分析 | [1D 欧拉梁变形](./examples/euler_beam.md) | ✅ | | ✅ | ✅ |
     | 受力分析 | [2D 平板变形](./examples/biharmonic2d.md) | ✅ | | | ✅ |
     | 受力分析 | [3D 连接件变形](./examples/bracket.md) | ✅ | | | |
     | 受力分析 | [结构震动模拟](./examples/phylstm.md) | ✅ | | | ✅ |


### PR DESCRIPTION
### PR types
New features

### PR changes
Docs

### Describe
为数学领域的deeponet,laplace,lorenz,euler_beam等模型添加太初硬件支持信息

### Environments
![image](https://github.com/user-attachments/assets/b1ae5e88-b445-4aa2-a01d-e590f2d64e7f)
芯片型号：T100
各组件版本信息如上图所示，包括驱动、算子库等全部依赖组件

### Logs
[deeponet_train.log](https://github.com/user-attachments/files/19416680/deeponet_train.log)
[deeponet_eval.log](https://github.com/user-attachments/files/19416681/deeponet_eval.log)
[euler_beam_eval.log](https://github.com/user-attachments/files/19416682/euler_beam_eval.log)
[euler_beam_train.log](https://github.com/user-attachments/files/19416683/euler_beam_train.log)
[laplace2d_eval.log](https://github.com/user-attachments/files/19416684/laplace2d_eval.log)
[laplace2d_train.log](https://github.com/user-attachments/files/19416685/laplace2d_train.log)
[lorenz_transformer_eval.log](https://github.com/user-attachments/files/19416687/lorenz_transformer_eval.log)
[lorenz_transformer_train.log](https://github.com/user-attachments/files/19416688/lorenz_transformer_train.log)
pdparams文件较大，无法上传，如有所需，请联系开发者单独提供

### Results
deeponet sdaa精度值：
    loss(G_eval): 0.00002
    L2Rel.G(G_eval): 0.01464
deeponet cuda精度值：
    loss(G_eval): 0.00003
    L2Rel.G(G_eval): 0.01799

Euler_Beams sdaa精度值：
    loss(L2Rel_Metric): 0.00000
    L2Rel.u(L2Rel_Metric): 0.00061
Euler_Beams cuda精度值：
    loss(L2Rel_Metric): 0.00000
    L2Rel.u(L2Rel_Metric): 0.00058

Laplace sdaa精度值：
    loss(MSE_Metric): 0.00002
    MSE.u(MSE_Metric): 0.00002
Laplace cuda精度值：
    loss(MSE_Metric): 0.00002
    MSE.u(MSE_Metric): 0.00002

Lorenz sdaa精度值：
    0.074（MSE）
Lorenz cuda精度值：
    0.054（MSE）

均符合精度对齐要求



