### PR TITLE
[Fix] Fix linear_init_

### DIFF
--- a/ppsci/utils/initializer.py
+++ b/ppsci/utils/initializer.py
@@ -445,7 +445,7 @@ def linear_init_(module: nn.Layer) -> None:
         >>> layer = paddle.nn.Linear(128, 256)
         >>> ppsci.utils.initializer.linear_init_(layer)
     """
-    kaiming_uniform_(module.weight, a=math.sqrt(5))
+    kaiming_uniform_(module.weight, a=math.sqrt(5), reverse=True)
     if module.bias is not None:
         fan_in, _ = _calculate_fan_in_and_fan_out(module.weight, reverse=True)
         bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->

修复 `ppsci.utils.initializer.linear_init_`中，没有启用`reverse=True`，导致初始化分布不正确的问题（fan_in, fan_out计算反了)