### PR TITLE
[sdaa]:adapt NLS-MB model on custom device sdaa

### DIFF
--- a/docs/zh/multi_device.md
+++ b/docs/zh/multi_device.md
@@ -19,7 +19,7 @@
     | 微分方程 | [若斯叻方程](./examples/rossler.md) | ✅ | | ✅ | ✅ |
     | 算子学习 | [DeepONet](./examples/deeponet.md) | ✅ | | ✅ | ✅ |
     | 积分方程 | [沃尔泰拉积分方程](./examples/volterra_ide.md) | ✅ | | ✅ | ✅ |
-    | 光纤怪波 | [Optical rogue wave](./examples/nlsmb.md) | ✅ | | | ✅ |
+    | 光纤怪波 | [Optical rogue wave](./examples/nlsmb.md) | ✅ | | ✅ | ✅ |
     | 域分解 | [XPINN](./examples/xpinns.md) | ✅ | | ✅ | ✅ |
     | 布鲁塞尔扩散系统 | [3D-Brusselator](./examples/brusselator3d.md) | ✅ | | | |
     | 符号回归 | [Transformer4SR](./examples/transformer4sr.md) | ✅ | | | |


### PR DESCRIPTION
### PR types
New features

### PR changes
Docs

### Describe
为数学领域的NLS-MB模型添加太初硬件支持信息

### Environments
![image](https://github.com/user-attachments/assets/3c09f2ba-d896-44e9-b435-3ccb8f38b63a)
芯片型号：T100
各组件版本信息如上图所示，包括驱动、算子库等全部依赖组件

### Logs
[NLS-MB_optical_rogue_wave_train.log](https://github.com/user-attachments/files/19478228/NLS-MB_optical_rogue_wave_train.log)
[NLS-MB_optical_rogue_wave_eval.log](https://github.com/user-attachments/files/19478229/NLS-MB_optical_rogue_wave_eval.log)
[NLS-MB_soliton_pretrained_eval.log](https://github.com/user-attachments/files/19478230/NLS-MB_soliton_pretrained_eval.log)
[NLS-MB_soliton_pretrained_train.log](https://github.com/user-attachments/files/19478231/NLS-MB_soliton_pretrained_train.log)
pdparams文件较大，无法上传，如有所需，请联系开发者单独提供

### Results
在两个case上，sdaa和cuda上的精度值完全一致，均为：
    Residual/loss: 0.00000
    Residual/MSE.Schrodinger_1: 0.00000
    Residual/MSE.Schrodinger_2: 0.00000
    Residual/MSE.Maxwell_1: 0.00000
    Residual/MSE.Maxwell_2: 0.00000
    Residual/MSE.Bloch: 0.00000
符合精度对齐要求

