### PR TITLE
[Doc] Remove pdmodel in user_guide

### DIFF
--- a/docs/zh/development.md
+++ b/docs/zh/development.md
@@ -782,7 +782,7 @@ solver = ppsci.solver.Solver(
         INFER: # (42)
           pretrained_model_path: "https://paddle-org.bj.bcebos.com/paddlescience/models/viv/viv_pretrained.pdparams" # (43)
           export_path: ./inference/viv # (44)
-          pdmodel_path: ${INFER.export_path}.pdmodel # (45)
+          pdmodel_path: ${INFER.export_path}.json # (45)
           pdiparams_path: ${INFER.export_path}.pdiparams # (46)
           input_keys: ${MODEL.input_keys} # (47)
           output_keys: ["eta", "f"] # (48)
@@ -843,7 +843,7 @@ solver = ppsci.solver.Solver(
         42. `INFER:` - 开始定义推理（推断）相关的设置。
         43. `pretrained_model_path: "https://..."` - 指定预训练模型的路径，可以是实际路径或 url，用于推理。
         44. `export_path: ./inference/viv` - 设置模型导出路径，即推理所需的模型文件保存位置。
-        45. `pdmodel_path: ${INFER.export_path}.pdmodel` - 指定Paddle模型的结构文件路径。
+        45. `pdmodel_path: ${INFER.export_path}.json` - 指定Paddle模型的结构文件路径，后缀名可以是`.json`或`.pdmodel`。
         46. `pdiparams_path: ${INFER.export_path}.pdiparams` - 指定Paddle模型的参数文件路径。
         47. `input_keys: ${MODEL.input_keys}` - 推理时使用的输入键与模型定义时相同。
         48. `output_keys: ["eta", "f"]` - 设置推理时的输出键，包括"eta"和"f"。

--- a/docs/zh/user_guide.md
+++ b/docs/zh/user_guide.md
@@ -360,7 +360,7 @@ pip install "paddle2onnx>=2.0.0"
 
     少数案例尚未支持导出、推理功能，因此对应文档中未给出导出、推理命令。
 
-首先需参考 [1.2 模型导出](#12) 章节，从 `*.pdparams` 文件导出 `*.pdmodel`, `*.pdiparams` 两个文件。
+首先需参考 [1.2 模型导出](#12) 章节，从 `*.pdparams` 文件导出 `*.json`, `*.pdiparams` 两个文件。
 
 以 [Aneurysm](./examples/aneurysm.md) 案例为例，假设导出后的模型文件以 `./inference/aneurysm.*` 的形式保存，则推理代码示例如下。
 
@@ -478,7 +478,7 @@ PaddleScience 提供了多种推理配置组合，可通过命令行进行组合
 
     ONNX 是微软开源的深度学习推理框架，PaddleScience 支持了 ONNX 推理功能。
 
-    首先按照 [1.2.2 ONNX 推理模型导出](#122-onnx) 章节将 `*.pdmodel` 和 `*.pdiparams` 转换为 `*.onnx` 文件，
+    首先按照 [1.2.2 ONNX 推理模型导出](#122-onnx) 章节将 `*.json` 和 `*.pdiparams` 转换为 `*.onnx` 文件，
     然后根据硬件环境，安装 CPU 或 GPU 版的 onnxruntime：
 
     ``` sh


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->

移除关于老的推理模型格式 `pdmodel` 的说明，替换为基于PIR的新格式`.json`