### PR TITLE
[Fix] Fix `TimeXGeometry` wrong data genearation when given time_step

### DIFF
--- a/ppsci/geometry/geometry.py
+++ b/ppsci/geometry/geometry.py
@@ -134,6 +134,9 @@ class Geometry:
     ) -> Dict[str, np.ndarray]:
         """Sample random points in the geometry and return those meet criteria.
 
+        NOTE: sdf values returned by this function are negated because the weight in
+        loss function should be positive.
+
         Args:
             n (int): Number of points.
             random (Literal["pseudo", "Halton", "LHS"]): Random method. Defaults to "pseudo".
@@ -211,6 +214,7 @@ class Geometry:
 
         # if sdf_func added, return x_dict and sdf_dict, else, only return the x_dict
         if hasattr(self, "sdf_func"):
+            # NOTE: add negative to the sdf values because weight should be positive.
             sdf = -self.sdf_func(x)
             sdf_dict = misc.convert_to_dict(sdf, ("sdf",))
             sdf_derives_dict = {}

--- a/ppsci/geometry/mesh.py
+++ b/ppsci/geometry/mesh.py
@@ -582,7 +582,12 @@ class Mesh(geometry.Geometry):
         evenly: bool = False,
         compute_sdf_derivatives: bool = False,
     ):
-        """Sample random points in the geometry and return those meet criteria."""
+        """
+        Sample random points in the geometry and return those meet criteria.
+
+        NOTE: sdf values returned by this function are negated because the weight in
+        loss function should be positive.
+        """
         if evenly:
             # TODO(sensen): Implement uniform sample for mesh interior.
             raise NotImplementedError(
@@ -1112,7 +1117,12 @@ class SDFMesh(geometry.Geometry):
         evenly: bool = False,
         compute_sdf_derivatives: bool = False,
     ):
-        """Sample random points in the geometry and return those meet criteria."""
+        """
+        Sample random points in the geometry and return those meet criteria.
+
+        NOTE: sdf values returned by this function are negated because the weight in
+        loss function should be positive.
+        """
         if evenly:
             # TODO(sensen): Implement uniform sample for mesh interior.
             raise NotImplementedError(
@@ -1128,7 +1138,7 @@ class SDFMesh(geometry.Geometry):
         if compute_sdf_derivatives:
             sdf, sdf_derives = sdf
 
-        # NOTE: Negate sdf because weight should be positive.
+        # NOTE: add negative to the sdf values because weight should be positive.
         sdf_dict = misc.convert_to_dict(-sdf, ("sdf",))
 
         sdf_derives_dict = {}

--- a/ppsci/geometry/timedomain.py
+++ b/ppsci/geometry/timedomain.py
@@ -19,6 +19,7 @@ Code below is heavily based on [https://github.com/lululxvi/deepxde](https://git
 from __future__ import annotations
 
 import itertools
+import types
 from typing import Callable
 from typing import Dict
 from typing import Optional
@@ -61,19 +62,23 @@ class TimeDomain(geometry_1d.Interval):
         super().__init__(t0, t1)
         self.t0 = t0
         self.t1 = t1
+        assert (
+            time_step is None or timestamps is None
+        ), "time_step and timestamps cannot be both set."
         self.time_step = time_step
-        if timestamps is None:
-            self.timestamps = None
-        else:
+        if timestamps is not None:
             self.timestamps = np.array(
                 timestamps, dtype=paddle.get_default_dtype()
             ).reshape([-1])
-        if time_step is not None:
-            if time_step <= 0:
-                raise ValueError(f"time_step({time_step}) must be larger than 0.")
-            self.num_timestamps = int(np.ceil((t1 - t0) / time_step)) + 1
-        elif timestamps is not None:
-            self.num_timestamps = len(timestamps)
+            self.num_timestamps = len(self.timestamps)
+        elif time_step is not None:
+            # set timestamps manually with given time_step
+            self.timestamps = np.arange(
+                t0, t1, time_step, dtype=paddle.get_default_dtype()
+            )
+            self.num_timestamps = len(self.timestamps)
+        else:
+            self.timestamps = None
 
     def on_initial(self, t: np.ndarray) -> np.ndarray:
         """Check if a specific time is on the initial time point.
@@ -115,6 +120,35 @@ class TimeXGeometry(geometry.Geometry):
         self.geometry = geometry
         self.ndim = geometry.ndim + timedomain.ndim
 
+        if hasattr(self.geometry, "sdf_func"):
+
+            def sdf_func(self, points: np.ndarray) -> np.ndarray:
+                """Compute signed distance field.
+
+                Args:
+                    points (np.ndarray): The temporal-spatial coordinate points used to calculate
+                        the SDF value, the shape is [N, 1+D], where 1 represents the temporal
+                        dimension and D represents the spatial dimensions.
+
+                Returns:
+                    np.ndarray: SDF values of input points without squared, the shape is [N, 1].
+
+                NOTE: This function usually returns ndarray with negative values, because
+                according to the definition of SDF, the SDF value of the coordinate point inside
+                the object(interior points) is negative, the outside is positive, and the edge
+                is 0. Therefore, when used for weighting, a negative sign is often added before
+                the result of this function.
+                """
+                if points.shape[1] != self.ndim:
+                    raise ValueError(
+                        f"Shape of given points should be [*, {self.ndim}], but got {points.shape}"
+                    )
+                spatial_points = points[:, 1:]
+                sdf = self.geometry.sdf_func(spatial_points)
+                return sdf
+
+            self.sdf_func = types.MethodType(sdf_func, self)
+
     @property
     def dim_keys(self):
         return ("t",) + self.geometry.dim_keys
@@ -153,11 +187,10 @@ class TimeXGeometry(geometry.Geometry):
             >>> print(ts.shape)
             (1000, 3)
         """
-        if self.timedomain.time_step is not None:
-            # exclude start time t0
-            nt = int(np.ceil(self.timedomain.diam / self.timedomain.time_step))
-            nx = int(np.ceil(n / nt))
-        elif self.timedomain.timestamps is not None:
+        if (
+            self.timedomain.time_step is not None
+            or self.timedomain.timestamps is not None
+        ):
             # exclude start time t0
             nt = self.timedomain.num_timestamps - 1
             nx = int(np.ceil(n / nt))
@@ -211,7 +244,8 @@ class TimeXGeometry(geometry.Geometry):
             criteria (Optional[Callable]): A method that filters on the generated random points. Defaults to None.
 
         Returns:
-            np.ndarray: A set of random spatial-temporal points.
+            np.ndarray: A array of random spatial-temporal points with shape [N, 1+D], where 1 represents the
+            temporal dimension and D represents the spatial dimensions.
 
         Examples:
             >>> import ppsci
@@ -225,63 +259,14 @@ class TimeXGeometry(geometry.Geometry):
         if self.timedomain.time_step is None and self.timedomain.timestamps is None:
             raise ValueError("Either time_step or timestamps must be provided.")
         # time evenly and geometry random, if time_step if specified
-        if self.timedomain.time_step is not None:
-            nt = int(np.ceil(self.timedomain.diam / self.timedomain.time_step))
-            t = np.linspace(
-                self.timedomain.t1,
-                self.timedomain.t0,
-                num=nt,
-                endpoint=False,
-                dtype=paddle.get_default_dtype(),
-            )[:, None][
-                ::-1
-            ]  # [nt, 1]
+        if (
+            self.timedomain.time_step is not None
+            or self.timedomain.timestamps is not None
+        ):
             # 1. sample nx points in static geometry with criteria
-            nx = int(np.ceil(n / nt))
-            _size, _ntry, _nsuc = 0, 0, 0
-            x = np.empty(
-                shape=(nx, self.geometry.ndim), dtype=paddle.get_default_dtype()
-            )
-            while _size < nx:
-                _x = self.geometry.random_points(nx, random)
-                if criteria is not None:
-                    # fix arg 't' to None in criteria there
-                    criteria_mask = criteria(
-                        None, *np.split(_x, self.geometry.ndim, axis=1)
-                    ).flatten()
-                    _x = _x[criteria_mask]
-                if len(_x) > nx - _size:
-                    _x = _x[: nx - _size]
-                x[_size : _size + len(_x)] = _x
-
-                _size += len(_x)
-                _ntry += 1
-                if len(_x) > 0:
-                    _nsuc += 1
-
-                if _ntry >= 1000 and _nsuc == 0:
-                    raise ValueError(
-                        "Sample points failed, "
-                        "please check correctness of geometry and given criteria."
-                    )
-
-            # 2. repeat spatial points along time
-            tx = []
-            for ti in t:
-                tx.append(
-                    np.hstack(
-                        (np.full([nx, 1], ti, dtype=paddle.get_default_dtype()), x)
-                    )
-                )
-            tx = np.vstack(tx)
-            if len(tx) > n:
-                tx = tx[:n]
-            return tx
-        elif self.timedomain.timestamps is not None:
-            nt = self.timedomain.num_timestamps - 1
             t = self.timedomain.timestamps[1:]
+            nt = self.timedomain.num_timestamps - 1
             nx = int(np.ceil(n / nt))
-
             _size, _ntry, _nsuc = 0, 0, 0
             x = np.empty(
                 shape=(nx, self.geometry.ndim), dtype=paddle.get_default_dtype()
@@ -309,6 +294,7 @@ class TimeXGeometry(geometry.Geometry):
                         "please check correctness of geometry and given criteria."
                     )
 
+            # 2. repeat spatial points along time
             tx = []
             for ti in t:
                 tx.append(

--- a/test/geometry/test_timedomain_sdf.py
+++ b/test/geometry/test_timedomain_sdf.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from ppsci import geometry
+
+
+def test_sdf_of_TimeXGeometry():
+    timedomain = geometry.TimeDomain(0, 1, time_step=0.3)
+    geom = geometry.Rectangle((0, 0), (1, 1))
+    time_geom = geometry.TimeXGeometry(timedomain, geom)
+
+    interior_points = time_geom.sample_interior(
+        timedomain.num_timestamps * 3000, compute_sdf_derivatives=True
+    )
+
+    assert "sdf" in interior_points
+    assert "sdf__x" in interior_points
+    assert "sdf__y" in interior_points
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/geometry/test_timedomain_sdf.py
+++ b/test/geometry/test_timedomain_sdf.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import pytest
 
 from ppsci import geometry
@@ -29,6 +30,18 @@ def test_sdf_of_TimeXGeometry():
     assert "sdf" in interior_points
     assert "sdf__x" in interior_points
     assert "sdf__y" in interior_points
+
+    interior_points = {"x": np.linspace(-1, 1, dtype="float32").reshape((-1, 1))}
+    geom = geometry.PointCloud(interior_points, ("x",))
+    time_geom = geometry.TimeXGeometry(timedomain, geom)
+
+    interior_points = time_geom.sample_interior(
+        timedomain.num_timestamps * 10, compute_sdf_derivatives=True
+    )
+
+    assert "sdf" not in interior_points
+    assert "sdf__x" not in interior_points
+    assert "sdf__y" not in interior_points
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->

1. 修复`TimeDomain`自身的`timestamps`可能在某些情况下不能对齐用户给定`time_step`的BUG，此时会报错
2. 修复了`TimeXGeometry.sample_interior`无法返回 sdf 相关数据的问题，修复后会根据传入的 `geometry` 本身是否有`sdf_func`决定`TimeXGeometry.sample_interior`返回值是否有 sdf 相关数据

相关 issue: #1177 @pecanjk