### PR TITLE
[Fix] Support NumberSymbol for symbolic module and sympy.sympify for PDE

### DIFF
--- a/ppsci/equation/pde/biharmonic.py
+++ b/ppsci/equation/pde/biharmonic.py
@@ -56,9 +56,15 @@ class Biharmonic(base.PDE):
         u = self.create_function("u", invars)
 
         if isinstance(q, str):
-            q = self.create_function("q", invars)
+            if q == "q":
+                q = self.create_function("q", invars)
+            else:
+                q = sympy.sympify(q)
         if isinstance(D, str):
-            D = self.create_function("D", invars)
+            if D == "D":
+                D = self.create_function("D", invars)
+            else:
+                D = sympy.sympify(D)
 
         self.dim = dim
         self.q = q

--- a/ppsci/utils/symbolic.py
+++ b/ppsci/utils/symbolic.py
@@ -444,11 +444,12 @@ class ConstantNode(Node):
             or self.expr.is_Integer
             or self.expr.is_Boolean
             or self.expr.is_Rational
+            or isinstance(self.expr, sp.core.numbers.NumberSymbol)
         ):
             self.expr = float(self.expr)
         else:
             raise TypeError(
-                "expr({expr}) should be Float/Integer/Boolean/Rational, "
+                f"expr({expr}) should be Float/Integer/Boolean/Rational, "
                 f"but got {type(self.expr)}"
             )
         self.expr = paddle.to_tensor(self.expr)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->

1. 修复了符号表达式解析模块`symbolic`不支持sympy符号常数的情况
2. 为biharmonic方程支持了指定q或D为字符串表示的函数的情况