### PR TITLE
[sdaa]:adapt extformer and fourcast models on device sdaa

### DIFF
--- a/docs/zh/multi_device.md
+++ b/docs/zh/multi_device.md
@@ -73,8 +73,8 @@
 
     | 问题类型 | 案例名称 | NVIDIA | 海光 | 太初 | 沐曦 |
     |-----|-----|-----|-----|-----|-----|
-    | 天气预报 | [Extformer-MoE 气象预报](./examples/extformer_moe.md) | ✅ | | | ✅ |
-    | 天气预报 | [FourCastNet 气象预报](./examples/fourcastnet.md) | ✅ | | | |
+    | 天气预报 | [Extformer-MoE 气象预报](./examples/extformer_moe.md) | ✅ | | ✅ | ✅ |
+    | 天气预报 | [FourCastNet 气象预报](./examples/fourcastnet.md) | ✅ | | ✅ | |
     | 天气预报 | [NowCastNet 气象预报](./examples/nowcastnet.md) | ✅ | | | ✅ |
     | 天气预报 | [GraphCast 气象预报](./examples/graphcast.md) | ✅ | | ✅ | ✅ |
     | 天气预报 | [DGMR 气象预报](./examples/dgmr.md) | ✅ | | | |


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
为气象领域的extformer-moe和fourcastnet模型添加太初硬件支持信息

### Environments
<img width="1181" height="105" alt="494824841-948d464f-816d-46c0-87ae-ccaa2e9b8e4f" src="https://github.com/user-attachments/assets/dc608479-4a65-4407-97b4-5a3c60b477a3" />
芯片型号：T100 各组件版本信息如上图所示，包括驱动、算子库等全部依赖组件

### Logs
下面是extformer评估日志，暂时只支持评估和推理
[eval.log](https://github.com/user-attachments/files/22834305/eval.log)
<img width="1191" height="591" alt="屏幕截图 2025-10-10 114232" src="https://github.com/user-attachments/assets/3cf8e77d-446e-40dc-ac36-a2e1fd74a8d6" />
数据使用icar_enso_2021

fourcastnet由于数据集问题只支持使用预训练权重推理
<img width="2100" height="2100" alt="31" src="https://github.com/user-attachments/assets/60e4be1f-2e3e-49ed-bd06-78e376a73d89" />
![result](https://github.com/user-attachments/assets/eb567907-df2a-4102-8bd9-7e72395bf44a)
数据为ERA5的2018年04-04和09-08两天的数据


### Results
extformer-moe sdaa精度值：
C-Nino3.4-M: 0.76498
C-Nino3.4-WM: 2.39723
MSE: 0.00030
MAE: 0.01291
RMSE: 0.50263

均符合精度对齐要求


