### PR TITLE
[Chore] Fix typos and bugs

### DIFF
--- a/examples/earthformer/sevir_vis_seq.py
+++ b/examples/earthformer/sevir_vis_seq.py
@@ -49,9 +49,9 @@ def get_cmap_dict(s):
 
 
 def visualize_result(
-    in_seq: np.array,
-    target_seq: np.array,
-    pred_seq_list: List[np.array],
+    in_seq: np.ndarray,
+    target_seq: np.ndarray,
+    pred_seq_list: List[np.ndarray],
     label_list: List[str],
     interval_real_time: float = 10.0,
     idx=0,
@@ -64,8 +64,8 @@ def visualize_result(
 ):
     """
     Args:
-        in_seq (np.array):
-        target_seq (np.array):
+        in_seq (np.ndarray):
+        target_seq (np.ndarray):
         interval_real_time (float): The minutes of each plot interval
     """
 
@@ -214,9 +214,9 @@ def save_example_vis_results(
 ):
     """
     Args:
-    in_seq (np.array): float value 0-1
-    target_seq (np.array): float value 0-1
-    pred_seq (np.array): float value 0-1
+    in_seq (np.ndarray): float value 0-1
+    target_seq (np.ndarray): float value 0-1
+    pred_seq (np.ndarray): float value 0-1
     interval_real_time (float): The minutes of each plot interval
     """
 

--- a/jointContribution/CHGNet/chgnet/graph/graph.py
+++ b/jointContribution/CHGNet/chgnet/graph/graph.py
@@ -128,7 +128,7 @@ class Graph:
         Args:
             center_index (int): center node index
             neighbor_index (int): neighbor node index
-            image (np.array): the periodic cell image the neighbor is from
+            image (np.ndarray): the periodic cell image the neighbor is from
             distance (float): distance between center and neighbor.
             dist_tol (float): tolerance for distance comparison between edges.
                 Default = 1e-6

--- a/ppsci/arch/cuboid_transformer_encoder.py
+++ b/ppsci/arch/cuboid_transformer_encoder.py
@@ -79,10 +79,10 @@ class PatchMerging3D(nn.Layer):
         """
 
         Args:
-            x : (B, T, H, W, C)
+            x: (B, T, H, W, C)
 
         Returns:
-            out : Shape (B, T // downsample[0], H // downsample[1], W // downsample[2], out_dim)
+            out: Shape (B, T // downsample[0], H // downsample[1], W // downsample[2], out_dim)
         """
 
         B, T, H, W, C = x.shape
@@ -218,10 +218,10 @@ class PositionwiseFFN(nn.Layer):
     def forward(self, data):
         """
         Args:
-            x : Shape (B, seq_length, C_in)
+            data: Shape (B, seq_length, C_in)
 
         Returns:
-            out : Shape (B, seq_length, C_out)
+            out: Shape (B, seq_length, C_out)
         """
 
         residual = data
@@ -1464,7 +1464,7 @@ class CuboidTransformerEncoder(nn.Layer):
         """Get the shape of the output memory based on the input shape. This can be used for constructing the decoder.
 
         Returns:
-            mem_shapes : A list of shapes of the output memory
+            mem_shapes: A list of shapes of the output memory
         """
 
         if self.num_blocks == 1:
@@ -1480,7 +1480,7 @@ class CuboidTransformerEncoder(nn.Layer):
     def forward(self, x, global_vectors=None):
         """
         Args:
-            x : Shape (B, T, H, W, C)
+            x: Shape (B, T, H, W, C)
 
         Returns:
             out (List[paddle.Tensor,..]): A list of tensors from the bottom layer to the top layer of the encoder. For

--- a/ppsci/arch/extformer_moe_cuboid_encoder.py
+++ b/ppsci/arch/extformer_moe_cuboid_encoder.py
@@ -81,10 +81,10 @@ class PatchMerging3D(nn.Layer):
         """
 
         Args:
-            x : (B, T, H, W, C)
+            x: (B, T, H, W, C)
 
         Returns:
-            out : Shape (B, T // downsample[0], H // downsample[1], W // downsample[2], out_dim)
+            out: Shape (B, T // downsample[0], H // downsample[1], W // downsample[2], out_dim)
         """
 
         B, T, H, W, C = x.shape
@@ -242,10 +242,10 @@ class PositionwiseFFN(nn.Layer):
     def forward(self, data):
         """
         Args:
-            x : Shape (B, seq_length, C_in)
+            data: Shape (B, seq_length, C_in)
 
         Returns:
-            out : Shape (B, seq_length, C_out)
+            out: Shape (B, seq_length, C_out)
         """
 
         residual = data
@@ -1622,7 +1622,7 @@ class CuboidTransformerEncoder(nn.Layer):
         """Get the shape of the output memory based on the input shape. This can be used for constructing the decoder.
 
         Returns:
-            mem_shapes : A list of shapes of the output memory
+            mem_shapes: A list of shapes of the output memory
         """
 
         if self.num_blocks == 1:
@@ -1638,7 +1638,7 @@ class CuboidTransformerEncoder(nn.Layer):
     def forward(self, x, global_vectors=None):
         """
         Args:
-            x : Shape (B, T, H, W, C)
+            x: Shape (B, T, H, W, C)
 
         Returns:
             out (List[paddle.Tensor,..]): A list of tensors from the bottom layer to the top layer of the encoder. For

--- a/ppsci/arch/moflow_glow.py
+++ b/ppsci/arch/moflow_glow.py
@@ -303,7 +303,6 @@ class Block(nn.Layer):
 
         Args:
             x (paddle.Tensor): Input to squeeze or unsqueeze.
-            reverse (bool): Reverse the operation, i.e., unsqueeze.
 
         Returns:
             x (paddle.Tensor): Squeezed or unsqueezed tensor.

--- a/ppsci/data/dataset/cgcnn_dataset.py
+++ b/ppsci/data/dataset/cgcnn_dataset.py
@@ -120,10 +120,10 @@ class GaussianDistance(object):
         Apply Gaussian distance filter to a numpy distance array.
 
         Args:
-            distance (np.array): n-dimensional distance matrix of any shape.
+            distances(np.ndarray): n-dimensional distance matrix of any shape.
 
         Returns:
-            np.array: Expanded distance matrix with the last dimension of length len(self.filter).
+            np.ndarray: Expanded distance matrix with the last dimension of length len(self.filter).
         """
 
         return np.exp(

--- a/ppsci/data/dataset/enso_dataset.py
+++ b/ppsci/data/dataset/enso_dataset.py
@@ -82,7 +82,7 @@ def fold(data, size=36, stride=12):
         stride (int, optional): The step.Defaults to 12.
 
     Returns:
-        outdata (np.array): (N_, *).N/size is the number/width of sliding blocks
+        outdata (np.ndarray): (N_, *).N/size is the number/width of sliding blocks
     """
     if size % stride != 0:
         raise ValueError("size modulo stride should be zero")

--- a/ppsci/data/dataset/sevir_dataset.py
+++ b/ppsci/data/dataset/sevir_dataset.py
@@ -482,7 +482,7 @@ class SEVIRDataset(io.Dataset):
             data (Dict,optional): , data[imgt] is a data tensor with shape = (tmp_batch_size, height, width, raw_seq_len).
 
         Returns:
-            data (np.array): Updated data. Updated shape = (tmp_batch_size + 1, height, width, raw_seq_len).
+            data (np.ndarray): Updated data. Updated shape = (tmp_batch_size + 1, height, width, raw_seq_len).
         """
 
         imgtyps = np.unique([x.split("_")[0] for x in list(row.keys())])

--- a/ppsci/data/dataset/sevir_dataset.py
+++ b/ppsci/data/dataset/sevir_dataset.py
@@ -555,7 +555,7 @@ class SEVIRDataset(io.Dataset):
         """Loads a selected batch of events (not batch of sequences) into memory.
 
         Args:
-            idx (int): The index of the event in the batch.
+            event_idx (int): The index of the event in the batch.
             event_batch_size (int): Event_batch[i] = all_type_i_available_events[idx:idx + event_batch_size]
 
         Returns:

--- a/ppsci/experimental/math_module.py
+++ b/ppsci/experimental/math_module.py
@@ -160,7 +160,7 @@ def gaussian_integrate(
 
         Args:
             N (int): Number of points.
-            integration_domain (paddle.Tensor): Integration domain.
+            integration_domains (paddle.Tensor): Integration domain.
 
         Returns:
             Tuple[paddle.Tensor, paddle.Tensor, int]: Grid points, grid widths and

--- a/ppsci/utils/save_load.py
+++ b/ppsci/utils/save_load.py
@@ -16,12 +16,16 @@ from __future__ import annotations
 
 import os
 import os.path as osp
+import pickle
+import random
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Optional
 
+import numpy as np
 import paddle
+from paddle import distributed as dist
 
 from ppsci.utils import download
 from ppsci.utils import logger
@@ -174,10 +178,73 @@ def load_checkpoint(
 
     if equation is not None:
         if not osp.exists(f"{path}.pdeqn"):
-            logger.warning(f"{path}.pdeqn not found.")
+            num_learnable_params = sum(
+                [len(eq.learnable_parameters) for eq in equation.values()]
+            )
+            if num_learnable_params > 0:
+                logger.warning(
+                    f"There are a total of {num_learnable_params} learnable parameters"
+                    f" in the equation, but {path}.pdeqn not found."
+                )
             equation_dict = None
         else:
             equation_dict = paddle.load(f"{path}.pdeqn")
+
+    # load random states
+    if osp.exists(f"{path}.pdrng"):
+        logger.message(f"* Loading random states from {path}.pdrng")
+        with open(f"{path}.pdrng", "rb") as f:
+            rng_dict = pickle.load(f)
+
+        # restore Python random state
+        if "python_random_state" in rng_dict:
+            random.setstate(rng_dict["python_random_state"])
+
+        # restore NumPy random state
+        if "numpy_random_state" in rng_dict:
+            np.random.set_state(rng_dict["numpy_random_state"])
+
+        # restore Paddle CPU random state
+        if "paddle_random_state" in rng_dict:
+            paddle.framework.core.default_cpu_generator().set_state(
+                rng_dict["paddle_random_state"]
+            )
+
+        # restore Paddle CUDA random state (single GPU or all GPUs)
+        if paddle.is_compiled_with_cuda():
+            if (
+                "paddle_cuda_random_state_all" in rng_dict
+                and rng_dict["paddle_cuda_random_state_all"] is not None
+            ):
+                # restore all GPU states (for distributed training)
+                num_devices = dist.get_world_size() if dist.is_initialized() else 1
+                num_saved_rng_states = len(rng_dict["paddle_cuda_random_state_all"])
+                if num_saved_rng_states > num_devices:
+                    logger.warning(
+                        f"Number of saved CUDA RNG states ({num_saved_rng_states}) is greater than "
+                        f"current number of devices ({num_devices}). Some RNG states will be ignored."
+                    )
+                elif num_saved_rng_states < num_devices:
+                    logger.warning(
+                        f"Number of saved CUDA RNG states ({num_saved_rng_states}) is less than "
+                        f"current number of devices ({num_devices}). Some devices will use default RNG states."
+                    )
+                for i, state in enumerate(rng_dict["paddle_cuda_random_state_all"]):
+                    if i < num_devices:
+                        paddle.framework.core.default_cuda_generator(i).set_state(state)
+            elif (
+                "paddle_cuda_random_state" in rng_dict
+                and rng_dict["paddle_cuda_random_state"] is not None
+            ):
+                # restore single GPU state
+                paddle.framework.core.default_cuda_generator(
+                    paddle.framework._current_expected_place().gpu_device_id()
+                ).set_state(rng_dict["paddle_cuda_random_state"])
+    else:
+        logger.warning(
+            f"{path}.pdrng not found. Random states will not be restored, "
+            "which may affect training reproducibility."
+        )
 
     # set model state dict
     logger.message(f"* Loading model checkpoint from {path}.pdparams")
@@ -261,7 +328,7 @@ def save_checkpoint(
         >>> optimizer = ppsci.optimizer.Adam(0.001)(model)
         >>> save_load.save_checkpoint(model, optimizer, {"RMSE": 0.1}, output_dir="path/to/output/dir") # doctest: +SKIP
     """
-    if paddle.distributed.get_rank() != 0:
+    if dist.get_rank() != 0:
         return
 
     if output_dir is None:
@@ -298,6 +365,37 @@ def save_checkpoint(
 
     if aggregator is not None and aggregator.should_persist:
         paddle.save(aggregator.state_dict(), f"{ckpt_path}.pdagg")
+
+    # save random states for reproducible training
+    rng_dict = {
+        "python_random_state": random.getstate(),
+        "numpy_random_state": np.random.get_state(),
+        "paddle_random_state": paddle.framework.core.default_cpu_generator().get_state(),
+    }
+
+    # save CUDA random states if available
+    if paddle.is_compiled_with_cuda():
+        # get current GPU device id
+        try:
+            current_device = paddle.framework._current_expected_place().gpu_device_id()
+            rng_dict[
+                "paddle_cuda_random_state"
+            ] = paddle.framework.core.default_cuda_generator(current_device).get_state()
+
+            # for distributed training, save all GPU states
+            num_gpus = dist.get_world_size() if dist.is_initialized() else 1
+            if num_gpus > 1:
+                rng_dict["paddle_cuda_random_state_all"] = [
+                    paddle.framework.core.default_cuda_generator(i).get_state()
+                    for i in range(num_gpus)
+                ]
+        except Exception as e:
+            logger.warning(f"Failed to save CUDA random state: {e}")
+            rng_dict["paddle_cuda_random_state"] = None
+            rng_dict["paddle_cuda_random_state_all"] = None
+
+    with open(f"{ckpt_path}.pdrng", "wb") as f:
+        pickle.dump(rng_dict, f)
 
     if print_log:
         log_str = f"Finish saving checkpoint to: {ckpt_path}"

--- a/ppsci/utils/save_load.py
+++ b/ppsci/utils/save_load.py
@@ -16,16 +16,12 @@ from __future__ import annotations
 
 import os
 import os.path as osp
-import pickle
-import random
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Optional
 
-import numpy as np
 import paddle
-from paddle import distributed as dist
 
 from ppsci.utils import download
 from ppsci.utils import logger
@@ -178,73 +174,10 @@ def load_checkpoint(
 
     if equation is not None:
         if not osp.exists(f"{path}.pdeqn"):
-            num_learnable_params = sum(
-                [len(eq.learnable_parameters) for eq in equation.values()]
-            )
-            if num_learnable_params > 0:
-                logger.warning(
-                    f"There are a total of {num_learnable_params} learnable parameters"
-                    f" in the equation, but {path}.pdeqn not found."
-                )
+            logger.warning(f"{path}.pdeqn not found.")
             equation_dict = None
         else:
             equation_dict = paddle.load(f"{path}.pdeqn")
-
-    # load random states
-    if osp.exists(f"{path}.pdrng"):
-        logger.message(f"* Loading random states from {path}.pdrng")
-        with open(f"{path}.pdrng", "rb") as f:
-            rng_dict = pickle.load(f)
-
-        # restore Python random state
-        if "python_random_state" in rng_dict:
-            random.setstate(rng_dict["python_random_state"])
-
-        # restore NumPy random state
-        if "numpy_random_state" in rng_dict:
-            np.random.set_state(rng_dict["numpy_random_state"])
-
-        # restore Paddle CPU random state
-        if "paddle_random_state" in rng_dict:
-            paddle.framework.core.default_cpu_generator().set_state(
-                rng_dict["paddle_random_state"]
-            )
-
-        # restore Paddle CUDA random state (single GPU or all GPUs)
-        if paddle.is_compiled_with_cuda():
-            if (
-                "paddle_cuda_random_state_all" in rng_dict
-                and rng_dict["paddle_cuda_random_state_all"] is not None
-            ):
-                # restore all GPU states (for distributed training)
-                num_devices = dist.get_world_size() if dist.is_initialized() else 1
-                num_saved_rng_states = len(rng_dict["paddle_cuda_random_state_all"])
-                if num_saved_rng_states > num_devices:
-                    logger.warning(
-                        f"Number of saved CUDA RNG states ({num_saved_rng_states}) is greater than "
-                        f"current number of devices ({num_devices}). Some RNG states will be ignored."
-                    )
-                elif num_saved_rng_states < num_devices:
-                    logger.warning(
-                        f"Number of saved CUDA RNG states ({num_saved_rng_states}) is less than "
-                        f"current number of devices ({num_devices}). Some devices will use default RNG states."
-                    )
-                for i, state in enumerate(rng_dict["paddle_cuda_random_state_all"]):
-                    if i < num_devices:
-                        paddle.framework.core.default_cuda_generator(i).set_state(state)
-            elif (
-                "paddle_cuda_random_state" in rng_dict
-                and rng_dict["paddle_cuda_random_state"] is not None
-            ):
-                # restore single GPU state
-                paddle.framework.core.default_cuda_generator(
-                    paddle.framework._current_expected_place().gpu_device_id()
-                ).set_state(rng_dict["paddle_cuda_random_state"])
-    else:
-        logger.warning(
-            f"{path}.pdrng not found. Random states will not be restored, "
-            "which may affect training reproducibility."
-        )
 
     # set model state dict
     logger.message(f"* Loading model checkpoint from {path}.pdparams")
@@ -328,7 +261,7 @@ def save_checkpoint(
         >>> optimizer = ppsci.optimizer.Adam(0.001)(model)
         >>> save_load.save_checkpoint(model, optimizer, {"RMSE": 0.1}, output_dir="path/to/output/dir") # doctest: +SKIP
     """
-    if dist.get_rank() != 0:
+    if paddle.distributed.get_rank() != 0:
         return
 
     if output_dir is None:
@@ -365,37 +298,6 @@ def save_checkpoint(
 
     if aggregator is not None and aggregator.should_persist:
         paddle.save(aggregator.state_dict(), f"{ckpt_path}.pdagg")
-
-    # save random states for reproducible training
-    rng_dict = {
-        "python_random_state": random.getstate(),
-        "numpy_random_state": np.random.get_state(),
-        "paddle_random_state": paddle.framework.core.default_cpu_generator().get_state(),
-    }
-
-    # save CUDA random states if available
-    if paddle.is_compiled_with_cuda():
-        # get current GPU device id
-        try:
-            current_device = paddle.framework._current_expected_place().gpu_device_id()
-            rng_dict[
-                "paddle_cuda_random_state"
-            ] = paddle.framework.core.default_cuda_generator(current_device).get_state()
-
-            # for distributed training, save all GPU states
-            num_gpus = dist.get_world_size() if dist.is_initialized() else 1
-            if num_gpus > 1:
-                rng_dict["paddle_cuda_random_state_all"] = [
-                    paddle.framework.core.default_cuda_generator(i).get_state()
-                    for i in range(num_gpus)
-                ]
-        except Exception as e:
-            logger.warning(f"Failed to save CUDA random state: {e}")
-            rng_dict["paddle_cuda_random_state"] = None
-            rng_dict["paddle_cuda_random_state_all"] = None
-
-    with open(f"{ckpt_path}.pdrng", "wb") as f:
-        pickle.dump(rng_dict, f)
 
     if print_log:
         log_str = f"Finish saving checkpoint to: {ckpt_path}"

--- a/ppsci/visualize/__init__.py
+++ b/ppsci/visualize/__init__.py
@@ -62,8 +62,6 @@ def build_visualizer(cfg: DictConfig):
 
     Args:
         cfg (DictConfig): Visualizer(s) config list.
-        geom_dict (Dct[str, Geometry]): Geometry(ies) in dict.
-        equation_dict (Dct[str, Equation]): Equation(s) in dict.
 
     Returns:
         Dict[str, Visualizer]: Visualizer(s) in dict.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleScience/pull/96 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
This pull request focuses on improving code clarity and documentation by updating type annotations and argument names in function and method docstrings across several files. The changes primarily standardize the use of `np.ndarray` over `np.array`, clarify argument names, and correct minor docstring inconsistencies.

**Type annotation and docstring improvements:**

* Replaced all instances of `np.array` with `np.ndarray` in function and method docstrings for consistency and accuracy in `examples/earthformer/sevir_vis_seq.py`, `jointContribution/CHGNet/chgnet/graph/graph.py`, `ppsci/data/dataset/cgcnn_dataset.py`, `ppsci/data/dataset/enso_dataset.py`, and `ppsci/data/dataset/sevir_dataset.py`. [[1]](diffhunk://#diff-1f7518638f68a3471cf59cfe623dc8efe540dc32ed8ad2ec31cc6f81f9f669f5L52-R54) [[2]](diffhunk://#diff-1f7518638f68a3471cf59cfe623dc8efe540dc32ed8ad2ec31cc6f81f9f669f5L67-R68) [[3]](diffhunk://#diff-1f7518638f68a3471cf59cfe623dc8efe540dc32ed8ad2ec31cc6f81f9f669f5L217-R219) [[4]](diffhunk://#diff-ba54d2a27aaf5d93e1ee104d99f4dbff6a740554c176987b0d925c3e1b507759L131-R131) [[5]](diffhunk://#diff-f71655fb87e42f97b6ff12bf39056468db101730f3d688ce98a31f88927f6f8bL123-R126) [[6]](diffhunk://#diff-77d10c2f5b0575536bd9099ec9a3b47d558ac6bedb5ef7492b16a04d7c2fd811L85-R85) [[7]](diffhunk://#diff-79d5d7bb5b7dc3d39d647c899b95c91c7bf4d82c67ec7cf1bf4492dfe009cca3L485-R485)
* Updated the argument name in docstrings from `idx` to `event_idx` in `ppsci/data/dataset/sevir_dataset.py` for clarity.
* Changed the argument name in docstrings from `integration_domain` to `integration_domains` in `ppsci/experimental/math_module.py` to match the code.
* Updated the argument name in docstrings from `x` to `data` in the `forward` method of `ppsci/arch/cuboid_transformer_encoder.py` and `ppsci/arch/extformer_moe_cuboid_encoder.py` for consistency with the method signature. [[1]](diffhunk://#diff-042a1b520bbb50a26a7ce5f095ad8ab7d378de24bfe6284df76ba22c8ff3d784L221-R221) [[2]](diffhunk://#diff-33abb818a718814f639e640f214f75d4fab68d8a3daf614e2444c55f7ef9c923L245-R245)
* Removed an unused argument description (`reverse`) in the docstring for `_squeeze` in `ppsci/arch/moflow_glow.py`.
* Removed incorrect argument descriptions (`geom_dict`, `equation_dict`) from the docstring in `ppsci/visualize/__init__.py`.