### PR TITLE
[BUG]fix bugs in make_sdf function

### DIFF
--- a/ppsci/geometry/mesh.py
+++ b/ppsci/geometry/mesh.py
@@ -1360,44 +1360,38 @@ def sample_in_triangle(v0, v1, v2, n, random="pseudo", criteria=None):
 
 
 def make_sdf(vectors: np.ndarray):
-    def sdf_func(points: np.ndarray, compute_sdf_derivatives=False):
-        points = points.copy()
-        x_min, y_min, z_min = np.min(points, axis=0)
-        x_max, y_max, z_max = np.max(points, axis=0)
-        max_dis = max(max((x_max - x_min), (y_max - y_min)), (z_max - z_min))
-        store_triangles = vectors.copy()
-        store_triangles[:, :, 0] -= x_min
-        store_triangles[:, :, 1] -= y_min
-        store_triangles[:, :, 2] -= z_min
-        store_triangles *= 1 / max_dis
-        store_triangles = store_triangles.reshape([-1, 3])
-        points[:, 0] -= x_min
-        points[:, 1] -= y_min
-        points[:, 2] -= z_min
-        points *= 1 / max_dis
-        points = points.astype(np.float64).ravel()
+    verts = vectors.reshape(-1, 3)
+    v_min = verts.min(axis=0)
+    v_max = verts.max(axis=0)
+    max_dis = np.max(v_max - v_min)
+    norm_mesh = (verts - v_min) / max_dis
 
-        # compute sdf values
-        sdf = sdf_module.signed_distance_field(
-            store_triangles,
-            np.arange((store_triangles.shape[0])),
-            points,
+    mesh_vertices = [tuple(v) for v in norm_mesh.tolist()]
+    mesh_indices = np.arange(len(mesh_vertices), dtype=np.int32)
+
+    def sdf_func(points: np.ndarray, compute_sdf_derivatives=False):
+        pts = (points - v_min) / max_dis
+
+        input_points = [tuple(p) for p in pts.tolist()]
+
+        ret = sdf_module.signed_distance_field(
+            mesh_vertices,
+            mesh_indices,
+            input_points,
             include_hit_points=compute_sdf_derivatives,
         )
-        if compute_sdf_derivatives:
-            sdf, sdf_derives = sdf
-
-        sdf = sdf.numpy()
-        sdf = np.expand_dims(max_dis * sdf, axis=1)
 
         if compute_sdf_derivatives:
-            sdf_derives = sdf_derives.numpy().reshape(-1)
-            sdf_derives = -(sdf_derives - points)
-            sdf_derives = np.reshape(sdf_derives, (sdf_derives.shape[0] // 3, 3))
-            sdf_derives = sdf_derives / np.linalg.norm(
-                sdf_derives, axis=1, keepdims=True
-            )
-            return sdf, sdf_derives
+            sdf, grad = ret
+        else:
+            sdf = ret
+            grad = None
+
+        sdf = sdf.numpy().reshape(-1, 1) * max_dis
+
+        if grad is not None:
+            grad = grad.numpy().reshape(-1, 3)
+            return sdf, grad
 
         return sdf
 

--- a/ppsci/geometry/mesh.py
+++ b/ppsci/geometry/mesh.py
@@ -1382,15 +1382,19 @@ def make_sdf(vectors: np.ndarray):
         )
 
         if compute_sdf_derivatives:
-            sdf, grad = ret
+            sdf, hit_points = ret
         else:
             sdf = ret
-            grad = None
+            hit_points = None
 
         sdf = sdf.numpy().reshape(-1, 1) * max_dis
 
-        if grad is not None:
-            grad = grad.numpy().reshape(-1, 3)
+        if hit_points is not None:
+            hit_points = hit_points.numpy().reshape(-1, 3)
+            grad_vec = pts - hit_points
+            norms = np.linalg.norm(grad_vec, axis=1, keepdims=True)
+            norms[norms < 1e-6] = 1.0
+            grad = grad_vec / norms
             return sdf, grad
 
         return sdf


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1.原始的sdf_func会根据每批采样点动态调整边界，导致ppsci.geometry.Geometry.sample_interior函数采样内部点的时候，由于精度问题，sdf判断不一致：某批random_points判断为内部，整体计算sdf又被判定为外部。出现内部采样点的sdf距离存在负数的情况，最终表现为内部约束损失在多轮迭代后变成负数。这里统一改为采用原始几何来计算边界。
```ppsci.geometry.Geometry
class Geometry:
    ...

    def sample_interior(...) -> Dict[str, np.ndarray]:
            ...

                if misc.typename(self) == "TimeXGeometry":
                    points = self.random_points(n, random, criteria)
                else:
                    points = self.random_points(n, random)

            ...

        # if sdf_func added, return x_dict and sdf_dict, else, only return the x_dict
        if hasattr(self, "sdf_func"):
            # NOTE: add negative to the sdf values because weight should be positive.
            sdf = -self.sdf_func(x)
           
            ...
```
